### PR TITLE
Fix issue extending lease w/in prolong window

### DIFF
--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -478,7 +478,7 @@ class ManagerService(service_utils.RPCServer):
         try:
             values['user_id'] = lease['user_id']
             values['project_id'] = lease['project_id']
-            self.usage_enforcer.check_lease_duration(values)
+            self.usage_enforcer.check_lease_duration(values, lease=lease)
         except exceptions.RedisConnectionError:
             pass
 


### PR DESCRIPTION
When checking the lease duration when updating a lease, the existing
lease is not passed in, which means the ability to extend the release
within a prolong window is lost, as the block is never executed.