### PR TITLE
Modify Blazar to pick nodes randomly - Task #10843 

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -17,6 +17,7 @@
 import datetime
 import shlex
 import subprocess
+from random import shuffle
 
 from novaclient import exceptions as nova_exceptions
 from oslo_config import cfg
@@ -605,9 +606,11 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
             ]:
                 allocated_host_ids.append(host['id'])
         if len(not_allocated_host_ids) >= int(min_host):
+            shuffle(not_allocated_host_ids)
             return not_allocated_host_ids[:int(max_host)]
         all_host_ids = allocated_host_ids + not_allocated_host_ids
         if len(all_host_ids) >= int(min_host):
+            shuffle(all_host_ids)
             return all_host_ids[:int(max_host)]
         else:
             return []

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -15,9 +15,9 @@
 # under the License.
 
 import datetime
+from random import shuffle
 import shlex
 import subprocess
-from random import shuffle
 
 from novaclient import exceptions as nova_exceptions
 from oslo_config import cfg

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -1888,7 +1888,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             '[]', '[]', '3-3',
             datetime.datetime(2013, 12, 19, 20, 00),
             datetime.datetime(2013, 12, 19, 21, 00))
-        self.assertEqual(['host1', 'host2', 'host3'], result)
+        self.assertEqual(set(['host1', 'host2', 'host3']), set(result))
 
     def test_matching_hosts_allocated_hosts_with_cleaning_time(self):
         def host_allocation_get_all_by_values(**kwargs):
@@ -1920,7 +1920,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             '[]', '[]', '3-3',
             datetime.datetime(2013, 12, 19, 20, 00),
             datetime.datetime(2013, 12, 19, 21, 00))
-        self.assertEqual(['host1', 'host2', 'host3'], result)
+        self.assertEqual(set(['host1', 'host2', 'host3']), set(result))
 
     def test_matching_hosts_not_matching(self):
         host_get = self.patch(


### PR DESCRIPTION
This is for the rocky update. It just adds shuffle to the list of possible node choices. I had to update two unit tests so that they compare unordered sets of hosts rather than ordered lists.