### PR TITLE
Fix: Error Host + Network Lease

### DIFF
--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -595,7 +595,15 @@ class ManagerService(service_utils.RPCServer):
                                 {'status': status.event.IN_PROGRESS})
 
         with trusts.create_ctx_from_trust(lease['trust_id']) as ctx:
-            for reservation in lease['reservations']:
+            network_reservations = [
+                x for x in lease['reservations']
+                if x['resource_type'] == 'network']
+
+            reservations = [
+                x for x in lease['reservations']
+                if x not in network_reservations]
+
+            for reservation in reservations + network_reservations:
                 if reservation['status'] != status.reservation.DELETED:
                     plugin = self.plugins[reservation['resource_type']]
                     try:

--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -329,9 +329,8 @@ class NetworkPlugin(base.BasePlugin):
     def delete_port(self, neutron, ironic, port):
         if port['binding:vnic_type'] == 'baremetal':
             node = port.get('binding:host_id')
-            if node:
-                ironic.node.vif_detach(node, port['id'])
-            else:
+
+            if not node:
                 raise Exception("Expected to find attribute binding:host_id "
                                 "on port %s" % port['id'])
 

--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -329,8 +329,11 @@ class NetworkPlugin(base.BasePlugin):
     def delete_port(self, neutron, ironic, port):
         if port['binding:vnic_type'] == 'baremetal':
             node = port.get('binding:host_id')
+            node_info = ironic.node.get(node)
 
-            if not node:
+            if node and node_info.instance_uuid:
+                ironic.node.vif_detach(node, port['id'])
+            else:
                 raise Exception("Expected to find attribute binding:host_id "
                                 "on port %s" % port['id'])
 


### PR DESCRIPTION
This ensures blazar tears down host reservations before network reservations, and removes the need for network tear down to remove VIFs from ironic ports.