### PR TITLE
Add update_reservation to floating ip plugin

### DIFF
--- a/blazar/manager/exceptions.py
+++ b/blazar/manager/exceptions.py
@@ -229,7 +229,8 @@ class NotEnoughFloatingIPAvailable(exceptions.InvalidInput):
 
 class CantUpdateFloatingIPReservation(exceptions.BlazarException):
     code = 400
-    msg_fmt = _("Floating IP reservation update is not yet supported")
+    msg_fmt = _("Floating IP reservation cannot be updated with requested "
+                "parameters.")
 
 
 # Network plugin related exceptions

--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -530,8 +530,6 @@ class ManagerService(service_utils.RPCServer):
                     raise exceptions.CantUpdateParameter(
                         param='resource_type')
 
-                if reservation['resource_type'] == 'virtual:floatingip':
-                    raise exceptions.CantUpdateFloatingIPReservation()
                 self.plugins[resource_type].update_reservation(
                     reservation['id'], v)
 

--- a/blazar/plugins/base.py
+++ b/blazar/plugins/base.py
@@ -19,8 +19,6 @@ from oslo_config import cfg
 from oslo_log import log as logging
 import six
 
-from blazar.db import api as db_api
-
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
 
@@ -66,12 +64,10 @@ class BasePlugin(object):
         """Reserve resource."""
         pass
 
+    @abc.abstractmethod
     def update_reservation(self, reservation_id, values):
         """Update reservation."""
-        reservation_values = {
-            'resource_id': values['resource_id']
-        }
-        db_api.reservation_update(reservation_id, reservation_values)
+        pass
 
     @abc.abstractmethod
     def on_end(self, resource_id):

--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -717,10 +717,8 @@ class NetworkPlugin(base.BasePlugin):
         if kept_networks < 1:
             min_networks = 1 - kept_networks \
                 if (1 - kept_networks) > 0 else 0
-            max_networks = 1 - kept_networks
             network_ids_to_add = self._matching_networks(
                 network_properties, resource_properties,
-                str(min_networks) + '-' + str(max_networks),
                 dates_after['start_date'], dates_after['end_date'])
 
             if len(network_ids_to_add) < min_networks:

--- a/blazar/tests/manager/test_service.py
+++ b/blazar/tests/manager/test_service.py
@@ -54,6 +54,9 @@ class FakePlugin(base.BasePlugin):
     def reserve_resource(self, reservation_id, values):
         return None
 
+    def update_reservation(self, reservation_id, values):
+        return None
+
     def on_start(self, resource_id):
         return 'Resource %s should be started this moment.' % resource_id
 

--- a/blazar/tests/plugins/networks/test_network_plugin.py
+++ b/blazar/tests/plugins/networks/test_network_plugin.py
@@ -917,7 +917,6 @@ class NetworkPluginTestCase(tests.TestCase):
         matching_networks.assert_called_with(
             '["=", "$network_type", "vlan"]',
             '',
-            '1-1',
             datetime.datetime(2017, 7, 12, 20, 00),
             datetime.datetime(2017, 7, 12, 21, 00)
         )


### PR DESCRIPTION
Update reservation functionality was never implemented for floating ip plugins causing any update to a lease containing a floating ip to fail. 