### PR TITLE
Optimize host allocations sql query

### DIFF
--- a/blazar/db/sqlalchemy/utils.py
+++ b/blazar/db/sqlalchemy/utils.py
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from collections import defaultdict
 import datetime
 import sys
 
@@ -25,6 +26,7 @@ from blazar.db.sqlalchemy import models
 from blazar.manager import exceptions as mgr_exceptions
 from blazar.plugins import instances as instance_plugin
 from blazar.plugins import oshosts as host_plugin
+from blazar import status
 
 get_session = facade_wrapper.get_session
 
@@ -163,16 +165,51 @@ def get_reservation_allocations_by_host_ids(host_ids, start_date, end_date,
     session = get_session()
     border0 = models.Lease.end_date < start_date
     border1 = models.Lease.start_date > end_date
-    query = (session.query(models.Reservation, models.ComputeHostAllocation)
-             .join(models.Lease).join(models.ComputeHostAllocation)
-             .filter(models.ComputeHostAllocation.compute_host_id
-                     .in_(host_ids))
-             .filter(~sa.or_(border0, border1)))
+    fields = ['id', 'status', 'lease_id', 'start_date',
+              'end_date', 'lease_name', 'project_id']
+
+    reservations_query = (session.query(
+        models.Reservation.id,
+        models.Reservation.status,
+        models.Reservation.lease_id,
+        models.Lease.start_date,
+        models.Lease.end_date,
+        models.Lease.name,
+        models.Lease.project_id)
+        .join(models.Lease)
+        .filter(models.Reservation.deleted.is_(None))
+        .filter(sa.or_(
+            models.Lease.status.like(status.lease.ACTIVE),
+            models.Lease.status.like(status.lease.PENDING)))
+        .filter(sa.or_(
+            models.Reservation.status.like(status.reservation.ACTIVE),
+            models.Reservation.status.like(status.reservation.PENDING)))
+        .filter(~sa.or_(border0, border1)))
+
     if lease_id:
-        query = query.filter(models.Reservation.lease_id == lease_id)
+        reservations_query = reservations_query.filter(
+            models.Reservation.lease_id == lease_id)
     if reservation_id:
-        query = query.filter(models.Reservation.id == reservation_id)
-    return query.all()
+        reservations_query = reservations_query.filter(
+            models.Reservation.id == reservation_id)
+
+    reservations = [dict(zip(fields, r)) for r in reservations_query.all()]
+
+    allocations_query = (session.query(
+        models.ComputeHostAllocation.reservation_id,
+        models.ComputeHostAllocation.compute_host_id)
+        .filter(models.ComputeHostAllocation.reservation_id.in_(
+            list(set([x['id'] for x in reservations])))))
+
+    allocations = defaultdict(list)
+
+    for row in allocations_query.all():
+        allocations[row[0]].append(row[1])
+
+    for r in reservations:
+        r['host_ids'] = allocations[r['id']]
+
+    return reservations
 
 
 def get_plugin_reservation(resource_type, resource_id):

--- a/blazar/tests/db/sqlalchemy/test_utils.py
+++ b/blazar/tests/db/sqlalchemy/test_utils.py
@@ -39,7 +39,8 @@ def _get_fake_phys_reservation_values(lease_id=_get_fake_lease_uuid(),
                                       resource_id='1234'):
     return {'lease_id': lease_id,
             'resource_id': resource_id,
-            'resource_type': 'physical:host'}
+            'resource_type': 'physical:host',
+            'status': 'active'}
 
 
 def _get_fake_inst_reservation_values(lease_id=_get_fake_lease_uuid(),
@@ -66,8 +67,28 @@ def _get_fake_phys_lease_values(id=_get_fake_lease_uuid(),
             'reservations': [_get_fake_phys_reservation_values(
                 lease_id=id,
                 resource_id=resource_id)],
-            'events': []
+            'events': [],
+            'project_id': 'fake_project',
+            'status': 'ACTIVE'
             }
+
+
+def _create_allocation_dicts(lease_ids):
+    allocs = []
+
+    for lease_id in lease_ids:
+        reservations = db_api.reservation_get_all_by_lease_id(
+            lease_id)
+
+        for reservation in reservations:
+            allocs.append(
+                {
+                    'id': reservation['id'],
+                    'host_ids': [
+                        x['compute_host_id'] for x
+                        in db_api.host_allocation_get_all_by_values(
+                            reservation_id=reservation['id'])]})
+    return allocs
 
 
 def _create_physical_lease(values=_get_fake_phys_lease_values(),
@@ -85,6 +106,10 @@ def _create_physical_lease(values=_get_fake_phys_lease_values(),
         }
         db_api.host_allocation_create(allocation_values)
     return lease
+
+
+def _filter_dicts_for_keys(keys, items):
+    return [{k: v for k, v in x.items() if k in keys} for x in items]
 
 
 class SQLAlchemyDBUtilsTestCase(tests.DBTestCase):
@@ -408,72 +433,47 @@ class SQLAlchemyDBUtilsTestCase(tests.DBTestCase):
                                '2030-01-01 07:00', '2030-01-01 15:00')
 
     def test_get_reservation_allocations_by_host_ids(self):
-        def create_allocation_tuple(lease_id):
-            reservation = db_api.reservation_get_all_by_lease_id(lease_id)[0]
-            allocation = db_api.host_allocation_get_all_by_values(
-                reservation_id=reservation['id'])[0]
-            return (reservation['id'], allocation['id'])
-
         self._setup_leases()
 
         # query all allocations of lease1, lease2 and lease3
-        expected = [
-            create_allocation_tuple('lease1'),
-            create_allocation_tuple('lease2'),
-            create_allocation_tuple('lease3'),
-        ]
+        expected = _create_allocation_dicts(['lease1', 'lease2', 'lease3'])
         ret = db_utils.get_reservation_allocations_by_host_ids(
             ['r1', 'r2'], '2030-01-01 08:00', '2030-01-01 15:00')
 
-        self.assertListEqual(expected, [(r['id'], a['id']) for r, a in ret])
+        self.assertListEqual(
+            expected, _filter_dicts_for_keys(['id', 'host_ids'], ret))
 
         # query allocations of lease2 and lease3
-        expected = [
-            create_allocation_tuple('lease2'),
-            create_allocation_tuple('lease3'),
-        ]
+        expected = _create_allocation_dicts(['lease2', 'lease3'])
         ret = db_utils.get_reservation_allocations_by_host_ids(
             ['r1', 'r2'], '2030-01-01 11:30', '2030-01-01 15:00')
 
-        self.assertListEqual(expected, [(r['id'], a['id']) for r, a in ret])
+        self.assertListEqual(
+            expected, _filter_dicts_for_keys(['id', 'host_ids'], ret))
 
     def test_get_reservation_allocations_by_host_ids_with_lease_id(self):
-        def create_allocation_tuple(lease_id):
-            reservation = db_api.reservation_get_all_by_lease_id(lease_id)[0]
-            allocation = db_api.host_allocation_get_all_by_values(
-                reservation_id=reservation['id'])[0]
-            return (reservation['id'], allocation['id'])
-
         self._setup_leases()
 
         # query all allocations of lease1, lease2 and lease3
-        expected = [
-            create_allocation_tuple('lease1'),
-        ]
+        expected = _create_allocation_dicts(['lease1'])
         ret = db_utils.get_reservation_allocations_by_host_ids(
             ['r1', 'r2'], '2030-01-01 08:00', '2030-01-01 15:00', 'lease1')
 
-        self.assertListEqual(expected, [(r['id'], a['id']) for r, a in ret])
+        self.assertListEqual(
+            expected, _filter_dicts_for_keys(['id', 'host_ids'], ret))
 
     def test_get_reservation_allocations_by_host_ids_with_reservation_id(self):
-        def create_allocation_tuple(lease_id):
-            reservation = db_api.reservation_get_all_by_lease_id(lease_id)[0]
-            allocation = db_api.host_allocation_get_all_by_values(
-                reservation_id=reservation['id'])[0]
-            return (reservation['id'], allocation['id'])
-
         self._setup_leases()
         reservation1 = db_api.reservation_get_all_by_lease_id('lease1')[0]
 
         # query allocations of lease1
-        expected = [
-            create_allocation_tuple('lease1'),
-        ]
+        expected = _create_allocation_dicts(['lease1'])
         ret = db_utils.get_reservation_allocations_by_host_ids(
             ['r1', 'r2'], '2030-01-01 08:00', '2030-01-01 15:00',
             reservation_id=reservation1['id'])
 
-        self.assertListEqual(expected, [(r['id'], a['id']) for r, a in ret])
+        self.assertListEqual(
+            expected, _filter_dicts_for_keys(['id', 'host_ids'], ret))
 
     def test_get_plugin_reservation_with_host(self):
         patch_host_reservation_get = self.patch(db_api, 'host_reservation_get')

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -204,12 +204,12 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         self.ServerManager = nova.ServerManager
 
-    def reservation_allocation_tuple(self, r_id, l_id, h_id):
-        return (
-            {
-                'id': r_id, 'lease_id': l_id,
-                'start_date': '2015-01-01', 'end_date': '2015-01-02'},
-            {'compute_host_id': h_id})
+    def reservation_allocation_dict(self, r_id, l_id, p_id, h_ids):
+        return {
+            'id': r_id, 'status': 'active', 'lease_id': l_id,
+            'start_date': '2015-01-01', 'end_date': '2015-01-02',
+            'lease_name': l_id, 'project_id': p_id,
+            'host_ids': h_ids}
 
     def test_get_host(self):
         host = self.fake_phys_plugin.get_computehost(self.fake_host_id)
@@ -459,27 +459,15 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_tuple(*r) for r
+            self.reservation_allocation_dict(*r) for r
             in [
-                ('reservation-1', 'lease-1', 'host-1'),
-                ('reservation-1', 'lease-1', 'host-2'),
-                ('reservation-2', 'lease-1', 'host-2'),
-                ('reservation-2', 'lease-1', 'host-3'),
-                ('reservation-3', 'lease-2', 'host-1')]]
+                ('reservation-1', 'lease-1',
+                 'project-1', ['host-1', 'host-2']),
+                ('reservation-2', 'lease-1',
+                 'project-1', ['host-2', 'host-3']),
+                ('reservation-3', 'lease-2', 'project-2', ['host-1'])]]
 
-        self.db_lease_list = self.patch(self.db_api, 'lease_list')
         self.db_host_list = self.patch(self.db_api, 'host_list')
-
-        self.db_lease_list.return_value = [
-            {
-                'id': 'lease-1',
-                'start_date': '2015-01-01',
-                'end_date': '2015-01-02'},
-            {
-                'id': 'lease-2',
-                'start_date': '2015-01-01',
-                'end_date': '2015-01-02'}]
-
         self.db_host_list.return_value = [
             {'id': 'host-1'}, {'id': 'host-2'}, {'id': 'host-3'}]
 
@@ -525,21 +513,14 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_tuple(*r) for r
+            self.reservation_allocation_dict(*r) for r
             in [
-                ('reservation-1', 'lease-1', 'host-1'),
-                ('reservation-1', 'lease-1', 'host-2'),
-                ('reservation-2', 'lease-1', 'host-2'),
-                ('reservation-2', 'lease-1', 'host-3')]]
+                ('reservation-1', 'lease-1',
+                 'project-1', ['host-1', 'host-2']),
+                ('reservation-2', 'lease-1',
+                 'project-1', ['host-2', 'host-3'])]]
 
-        self.db_lease_list = self.patch(self.db_api, 'lease_list')
         self.db_host_list = self.patch(self.db_api, 'host_list')
-
-        self.db_lease_list.return_value = [{
-            'id': 'lease-1',
-            'start_date': '2015-01-01',
-            'end_date': '2015-01-02'}]
-
         self.db_host_list.return_value = [
             {'id': 'host-1'}, {'id': 'host-2'}, {'id': 'host-3'}]
 
@@ -583,21 +564,13 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_tuple(*r) for r
+            self.reservation_allocation_dict(*r) for r
             in [
-                ('reservation-1', 'lease-1', 'host-1'),
-                ('reservation-1', 'lease-1', 'host-2')]]
+                ('reservation-1', 'lease-1',
+                 'project-1', ['host-1', 'host-2'])]]
 
-        self.db_lease_list = self.patch(self.db_api, 'lease_list')
         self.db_host_list = self.patch(self.db_api, 'host_list')
-
-        self.db_lease_list.return_value = [{
-            'id': 'lease-1',
-            'start_date': '2015-01-01',
-            'end_date': '2015-01-02'}]
-
-        self.db_host_list.return_value = [
-            {'id': 'host-1'}, {'id': 'host-2'}]
+        self.db_host_list.return_value = [{'id': 'host-1'}, {'id': 'host-2'}]
 
         expected = [
             {
@@ -631,27 +604,15 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_tuple(*r) for r
+            self.reservation_allocation_dict(*r) for r
             in [
-                ('reservation-1', 'lease-1', 'host-1'),
-                ('reservation-1', 'lease-1', 'host-2'),
-                ('reservation-2', 'lease-1', 'host-2'),
-                ('reservation-2', 'lease-1', 'host-3'),
-                ('reservation-3', 'lease-2', 'host-1')]]
+                ('reservation-1', 'lease-1',
+                 'project-1', ['host-1', 'host-2']),
+                ('reservation-2', 'lease-1',
+                 'project-1', ['host-2', 'host-3']),
+                ('reservation-3', 'lease-2', 'project-2', ['host-1'])]]
 
-        self.db_lease_list = self.patch(self.db_api, 'lease_list')
         self.db_host_list = self.patch(self.db_api, 'host_list')
-
-        self.db_lease_list.return_value = [
-            {
-                'id': 'lease-1',
-                'start_date': '2015-01-01',
-                'end_date': '2015-01-02'},
-            {
-                'id': 'lease-2',
-                'start_date': '2015-01-01',
-                'end_date': '2015-01-02'}]
-
         self.db_host_list.return_value = [
             {'id': 'host-1'}, {'id': 'host-2'}, {'id': 'host-3'}]
 
@@ -677,18 +638,11 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_tuple(
-                'reservation-1', 'lease-1', 'host-1'),
+            self.reservation_allocation_dict(
+                'reservation-1', 'lease-1', 'project-1', ['host-1']),
         ]
 
-        self.db_lease_list = self.patch(self.db_api, 'lease_list')
         self.db_host_list = self.patch(self.db_api, 'host_list')
-
-        self.db_lease_list.return_value = [{
-            'id': 'lease-1',
-            'start_date': '2015-01-01',
-            'end_date': '2015-01-02'}]
-
         self.db_host_list.return_value = [{'id': 'host-1'}]
 
         expected = {
@@ -711,18 +665,10 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_tuple(
-                'reservation-1', 'lease-1', 'host-1'),
-        ]
+            self.reservation_allocation_dict(
+                'reservation-1', 'lease-1', 'project-1', ['host-1'])]
 
-        self.db_lease_list = self.patch(self.db_api, 'lease_list')
         self.db_host_list = self.patch(self.db_api, 'host_list')
-
-        self.db_lease_list.return_value = [{
-            'id': 'lease-1',
-            'start_date': '2015-01-01',
-            'end_date': '2015-01-02'}]
-
         self.db_host_list.return_value = [{'id': 'host-1'}]
 
         expected = {
@@ -745,27 +691,15 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_tuple(*r) for r
+            self.reservation_allocation_dict(*r) for r
             in [
-                ('reservation-1', 'lease-1', 'host-1'),
-                ('reservation-1', 'lease-1', 'host-2'),
-                ('reservation-2', 'lease-1', 'host-2'),
-                ('reservation-2', 'lease-1', 'host-3'),
-                ('reservation-3', 'lease-2', 'host-1')]]
+                ('reservation-1', 'lease-1',
+                 'project-1', ['host-1', 'host-2']),
+                ('reservation-2', 'lease-1',
+                 'project-1', ['host-2', 'host-3']),
+                ('reservation-3', 'lease-2', 'project-2', ['host-1'])]]
 
-        self.db_lease_list = self.patch(self.db_api, 'lease_list')
         self.db_host_list = self.patch(self.db_api, 'host_list')
-
-        self.db_lease_list.return_value = [
-            {
-                'id': 'lease-1',
-                'start_date': '2015-01-01',
-                'end_date': '2015-01-02'},
-            {
-                'id': 'lease-2',
-                'start_date': '2015-01-01',
-                'end_date': '2015-01-02'}]
-
         self.db_host_list.return_value = [
             {'id': 'host-1'}, {'id': 'host-2'}, {'id': 'host-3'}]
 


### PR DESCRIPTION
The get_reservation_allocations_by_host_ids is a bottleneck in transitioning blazar-dashboard to using the api rather than directly hitting the database. The original query used to grab host allocations joined three tables. The raw sql based on the ORM could take up to 40 seconds pull all advanced reservations. This breaks up the query into two separate queries. The raw sql for both can be completed less than a second.