### PR TITLE
Set timeout on initial redis socket connection

### DIFF
--- a/blazar/manager/enforcement.py
+++ b/blazar/manager/enforcement.py
@@ -85,8 +85,10 @@ class UsageEnforcer(object):
             if not CONF.enforcement.usage_db_host:
                 raise common_ex.ConfigurationError(
                     'usage_db_host must be set when using usage_enforcement')
-        self.redis = redis.StrictRedis(host=CONF.enforcement.usage_db_host,
-                                       port=6379, db=0)
+
+            self.redis = redis.StrictRedis(host=CONF.enforcement.usage_db_host,
+                                           port=6379, db=0,
+                                           socket_connect_timeout=5.0)
 
     def _project_max_lease_durations(self):
         """Parses per-project maximum lease duration


### PR DESCRIPTION
If the Redis server is unreachable, the default behavior is that the
socket will block until it receives some sort of low-level timeout,
likely on the Linux network interface itself. This means that Blazar can
get stuck for a significant amount of time waiting for this connection
to establish for the purposes of enforcement.

Add a socket_connect_timeout option supported by the redis client set to
a low but charitable default of 5 seconds.

Also fix so the redis client isn't even created if usage enforcement is
not enabled; there is no reason to initialize/connect the client if the
entire feature is off.

Change-Id: Idebc7b75ee9e41f5264559d89e7fd265fcf2c45d