### PR TITLE
204 Response Patch

### DIFF
--- a/blazar/api/v1/utils.py
+++ b/blazar/api/v1/utils.py
@@ -248,10 +248,10 @@ def render(result=None, response_type=None, status=None, **kwargs):
         return
 
     body = serializer.dump_as_bytes(result)
-
     response_type = str(response_type)
+    headers = {'Content-Length': 0} if status_code == 204 else None
 
-    return flask.Response(response=body, status=status_code,
+    return flask.Response(response=body, headers=headers, status=status_code,
                           mimetype=response_type)
 
 


### PR DESCRIPTION
After upgrading to train release, the DELETE http method for Blazar API began
responding with errors to requests. The problem appears to be due to an
underlying problem with how HAProxy is handling of a null value in the
Content-Length header. Setting the content-length header to 0 for 204
responses seems to provides us with a workaround. The underlying problem
may be related to older versions of dependencies.