### PR TITLE
Keep service threadgroups alive on exception

### DIFF
--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -81,7 +81,8 @@ class ManagerService(service_utils.RPCServer):
 
     def start(self):
         super(ManagerService, self).start()
-        self.tg.add_timer(EVENT_INTERVAL, self._process_events)
+        self.tg.add_timer_args(EVENT_INTERVAL, self._process_events,
+                               stop_on_exception=False)
         for m in self.monitors:
             m.start_monitoring()
 


### PR DESCRIPTION
If the db connection is severed, blazar-manager service fails to
re-establish the connection because the timer for worker threadgroups
are set to fail on any exception. If we set the timer continue running
after an exception then blazar can attempt to re-establish connection
to a live db.

Closes-Bug: #1845531