### PR TITLE
Fix issue with updating extra capabilities

### DIFF
--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -482,7 +482,7 @@ class NetworkPlugin(base.BasePlugin):
                 host=network['id'])
         return self.get_network(network['id'])
 
-    def is_updatable_extra_capability(self, capability):
+    def is_updatable_extra_capability(self, capability, capability_name):
         reservations = db_utils.get_reservations_by_network_id(
             capability['network_id'], datetime.datetime.utcnow(),
             datetime.date.max)
@@ -499,7 +499,7 @@ class NetworkPlugin(base.BasePlugin):
             # the extra_capability.
             for requirement in requirements_queries:
                 # A requirement is of the form "key op value" as string
-                if requirement.split(" ")[0] == capability['capability_name']:
+                if requirement.split(" ")[0] == capability_name:
                     return False
         return True
 
@@ -537,26 +537,24 @@ class NetworkPlugin(base.BasePlugin):
         new_keys = set(values.keys()) - set(previous_capabilities.keys())
 
         for key in updated_keys:
-            raw_capability = next(iter(
+            raw_capability, cap_name = next(iter(
                 db_api.network_extra_capability_get_all_per_name(
                     network_id, key)))
             capability = {
                 'capability_name': key,
                 'capability_value': values[key],
             }
-            if self.is_updatable_extra_capability(raw_capability):
+            if self.is_updatable_extra_capability(raw_capability, cap_name):
                 try:
                     db_api.network_extra_capability_update(
                         raw_capability['id'], capability)
                 except (db_ex.BlazarDBException, RuntimeError):
-                    cant_update_extra_capability.append(
-                        raw_capability['capability_name'])
+                    cant_update_extra_capability.append(cap_name)
             else:
                 LOG.info("Capability %s can't be updated because "
                          "existing reservations require it.",
-                         raw_capability['capability_name'])
-                cant_update_extra_capability.append(
-                    raw_capability['capability_name'])
+                         cap_name)
+                cant_update_extra_capability.append(cap_name)
 
         for key in new_keys:
             new_capability = {
@@ -567,8 +565,7 @@ class NetworkPlugin(base.BasePlugin):
             try:
                 db_api.network_extra_capability_create(new_capability)
             except (db_ex.BlazarDBException, RuntimeError):
-                cant_update_extra_capability.append(
-                    new_capability['capability_name'])
+                cant_update_extra_capability.append(key)
 
         if cant_update_extra_capability:
             raise manager_ex.CantAddExtraCapability(

--- a/blazar/tests/plugins/networks/test_network_plugin.py
+++ b/blazar/tests/plugins/networks/test_network_plugin.py
@@ -232,11 +232,10 @@ class NetworkPluginTestCase(tests.TestCase):
         network_values = {'foo': 'baz'}
 
         self.db_network_extra_capability_get_all_per_name.return_value = [
-            {'id': 'extra_id1',
-             'network_id': self.fake_network_id,
-             'capability_name': 'foo',
-             'capability_value': 'bar'
-             },
+            ({'id': 'extra_id1',
+              'network_id': self.fake_network_id,
+              'capability_value': 'bar'},
+             'foo')
         ]
 
         self.get_reservations_by_network = self.patch(
@@ -256,11 +255,10 @@ class NetworkPluginTestCase(tests.TestCase):
             self.db_utils, 'get_reservations_by_network_id')
         self.get_reservations_by_network.return_value = []
         self.db_network_extra_capability_get_all_per_name.return_value = [
-            {'id': 'extra_id1',
-             'network_id': self.fake_network_id,
-             'capability_name': 'foo',
-             'capability_value': 'bar'
-             },
+            ({'id': 'extra_id1',
+              'network_id': self.fake_network_id,
+              'capability_value': 'bar'},
+             'foo')
         ]
         fake = self.db_network_extra_capability_update
         fake.side_effect = fake_db_network_extra_capability_update
@@ -284,11 +282,10 @@ class NetworkPluginTestCase(tests.TestCase):
         network_values = {'foo': 'buzz'}
 
         self.db_network_extra_capability_get_all_per_name.return_value = [
-            {'id': 'extra_id1',
-             'network_id': self.fake_network_id,
-             'capability_name': 'foo',
-             'capability_value': 'bar'
-             },
+            ({'id': 'extra_id1',
+              'network_id': self.fake_network_id,
+              'capability_value': 'bar'},
+             'foo')
         ]
         fake_network_reservation = {
             'resource_type': plugin.RESOURCE_TYPE,

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -316,11 +316,10 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         host_values = {'foo': 'baz'}
 
         self.db_host_extra_capability_get_all_per_name.return_value = [
-            {'id': 'extra_id1',
-             'computehost_id': self.fake_host_id,
-             'capability_name': 'foo',
-             'capability_value': 'bar'
-             },
+            ({'id': 'extra_id1',
+              'computehost_id': self.fake_host_id,
+              'capability_value': 'bar'},
+             'foo'),
         ]
 
         self.get_reservations_by_host = self.patch(
@@ -340,11 +339,10 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             self.db_utils, 'get_reservations_by_host_id')
         self.get_reservations_by_host.return_value = []
         self.db_host_extra_capability_get_all_per_name.return_value = [
-            {'id': 'extra_id1',
-             'computehost_id': self.fake_host_id,
-             'capability_name': 'foo',
-             'capability_value': 'bar'
-             },
+            ({'id': 'extra_id1',
+              'computehost_id': self.fake_host_id,
+              'capability_value': 'bar'},
+             'foo'),
         ]
         fake = self.db_host_extra_capability_update
         fake.side_effect = fake_db_host_extra_capability_update
@@ -368,11 +366,10 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         host_values = {'foo': 'buzz'}
 
         self.db_host_extra_capability_get_all_per_name.return_value = [
-            {'id': 'extra_id1',
-             'computehost_id': self.fake_host_id,
-             'capability_name': 'foo',
-             'capability_value': 'bar'
-             },
+            ({'id': 'extra_id1',
+              'computehost_id': self.fake_host_id,
+              'capability_value': 'bar'},
+             'foo'),
         ]
         fake_phys_reservation = {
             'resource_type': plugin.RESOURCE_TYPE,


### PR DESCRIPTION
Updating extra capabilities was broken and generated messages like this:

    File ".../blazar/plugins/oshosts/host_plugin.py", line 525, in update_computehost
      if self.is_updatable_extra_capability(raw_capability):
    File ".../blazar/plugins/oshosts/host_plugin.py", line 491, in is_updatable_extra_capability
      capability['computehost_id'], datetime.datetime.utcnow(),
    TypeError: tuple indices must be integers, not str

The issue seems to be that the query result returned from SQLalchemy is
a list of tuples, with the first item being the plugin-specific extra
capability (e.g., `ComputeHostExtraCapability`), and the second item
being the capability name.

I initially tried removing the `add_column`, which was adding the
capability_name to the result set explicitly, but I think that's the
only way you can get this data--it's just as part of a tuple and not
part of the representation.

Change-Id: I2cdbea6a4c57ca86b2989f958ec0049375c5e28c