### PR TITLE
show actual enforcement filter error messages

### DIFF
--- a/blazar/enforcement/filters/external_service_filter.py
+++ b/blazar/enforcement/filters/external_service_filter.py
@@ -44,7 +44,7 @@ class ExternalServiceUnsupportedHTTPResponse(exceptions.BlazarException):
                 'Only 204 and 403 responses are supported.')
 
 
-class ExternalServiceFilterException(exceptions.BlazarException):
+class ExternalServiceFilterException(exceptions.NotAuthorized):
     code = 400
     msg_fmt = _('%(message)s')
 

--- a/blazar/enforcement/filters/max_reservation_length_filter.py
+++ b/blazar/enforcement/filters/max_reservation_length_filter.py
@@ -31,13 +31,13 @@ DEFAULT_RESERVATION_EXTENTSION_WINDOW = -1
 LOG = logging.getLogger(__name__)
 
 
-class MaxReservationLengthException(exceptions.BlazarException):
+class MaxReservationLengthException(exceptions.NotAuthorized):
     code = 400
     msg_fmt = _('Lease length of %(lease_length)s seconds be less than or '
                 'equal the maximum lease length of %(max_length)s seconds.')
 
 
-class MaxReservationUpdateWindowException(exceptions.BlazarException):
+class MaxReservationUpdateWindowException(exceptions.NotAuthorized):
     code = 400
     msg_fmt = _('Lease can only be extended within %(extension_window)s '
                 'seconds of the leases current end time.')


### PR DESCRIPTION
When lease creation or updating fails on enforcement checks, it raises an
error that is surfaced to the user as a 500 Internal Service Error, which
is not very useful. The fix will show the actual error messages.