### PR TITLE
removing preemptible instance when adding node to aggregate

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -199,19 +199,6 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                 parameters=dict(
                     reservation_id=host_reservation['reservation_id']))
 
-        for host in hosts:
-            for server in self.nova.servers.list(
-                    search_opts={"node": host, "all_tenants": 1}):
-                try:
-                    LOG.info('Terminating preemptible instance %s (%s)',
-                             server.name, server.id)
-                    self.nova.servers.delete(server=server)
-                except nova_exceptions.NotFound:
-                    LOG.info('Could not find server %s, may have been deleted '
-                             'concurrently.', server)
-                except Exception as e:
-                    LOG.exception('Failed to delete %s: %s.', server, str(e))
-
     def before_end(self, resource_id, lease=None):
         """Take an action before the end of a lease."""
         host_reservation = db_api.host_reservation_get(resource_id)


### PR DESCRIPTION
Removing preemptible instance in on_start will only remove when
creating a new lease. Degrading lease and adding nodes to lease
will fail to remove preemptible instances on nodes, which will make
the node in the lease unusable. To solve, deleting preemptible
instance when adding node to non-freepool aggregate.