### PR TITLE
Add project-restricted devices

### DIFF
--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -456,6 +456,7 @@ class ManagerService(service_utils.RPCServer):
                         reservation['lease_id'] = lease['id']
                         reservation['start_date'] = lease['start_date']
                         reservation['end_date'] = lease['end_date']
+                        reservation['project_id'] = lease['project_id']
                         self._create_reservation(reservation)
                 except Exception:
                     with save_and_reraise_exception():

--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -805,6 +805,7 @@ class ManagerService(service_utils.RPCServer):
             resource_type = reservation['resource_type']
             res['start_date'] = lease['start_date']
             res['end_date'] = lease['end_date']
+            res['project_id'] = lease['project_id']
 
             if resource_type not in self.plugins:
                 raise exceptions.UnsupportedResourceType(

--- a/blazar/plugins/base.py
+++ b/blazar/plugins/base.py
@@ -150,8 +150,12 @@ class BasePlugin(object):
         return options
 
     def is_project_allowed(self, project_id, resource):
-        if "authorized_projects" in resource:
-            return project_id in resource["authorized_projects"]
+        # If this resource has the extra capability "authorized_projects"
+        if "authorized_projects" in resource and \
+                isinstance(resource["authorized_projects"], str):
+            # Parse the field as a CSV, and check the resulting list
+            authorized_projects = resource["authorized_projects"].split(",")
+            return project_id in authorized_projects
         return True
 
 

--- a/blazar/plugins/base.py
+++ b/blazar/plugins/base.py
@@ -149,6 +149,11 @@ class BasePlugin(object):
                       unsupported)
         return options
 
+    def is_project_allowed(self, project_id, resource):
+        if "authorized_projects" in resource:
+            return project_id in resource["authorized_projects"]
+        return True
+
 
 @six.add_metaclass(abc.ABCMeta)
 class BaseMonitorPlugin():

--- a/blazar/plugins/devices/device_plugin.py
+++ b/blazar/plugins/devices/device_plugin.py
@@ -100,9 +100,6 @@ class DevicePlugin(base.BasePlugin):
 
     def reserve_resource(self, reservation_id, values):
         """Create reservation."""
-        reservation = db_api.reservation_get(reservation_id)
-        lease = db_api.lease_get(reservation["lease_id"])
-        values["project_id"] = lease["project_id"]
         device_ids = self.allocation_candidates(values)
 
         if not device_ids:

--- a/blazar/tests/manager/test_service.py
+++ b/blazar/tests/manager/test_service.py
@@ -853,7 +853,8 @@ class ServiceTestCase(tests.TestCase):
                     'max': 3,
                     'resource_type': 'virtual:instance'
                 }
-            ]
+            ],
+            'project_id': u'e33c952e-6321-4ce6-93e3-c58d4925c5f8'
         }
         reservation_get_all = (
             self.patch(self.db_api, 'reservation_get_all_by_lease_id'))
@@ -1399,7 +1400,8 @@ class ServiceTestCase(tests.TestCase):
                     'max': 3,
                     'resource_type': 'virtual:instance'
                 }
-            ]
+            ],
+            'project_id': u'e33c952e-6321-4ce6-93e3-c58d4925c5f8'
         }
         reservation_get_all = (
             self.patch(self.db_api, 'reservation_get_all_by_lease_id'))

--- a/blazar/tests/plugins/test_base.py
+++ b/blazar/tests/plugins/test_base.py
@@ -1,0 +1,74 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from blazar.plugins import base
+from blazar import tests
+
+
+class BasePluginDummy(base.BasePlugin):
+    def get(self, resource_id):
+        pass
+
+    def reserve_resource(self, reservation_id, values):
+        pass
+
+    def list_allocations(self, query, detail=False):
+        pass
+
+    def query_allocations(self, resource_id_list, lease_id=None,
+                          reservation_id=None):
+        pass
+
+    def allocation_candidates(self, lease_values):
+        pass
+
+    def update_reservation(self, reservation_id, values):
+        pass
+
+    def on_end(self, resource_id, lease=None):
+        pass
+
+    def on_start(self, resource_id, lease=None):
+        pass
+
+
+class BasePluginTestCase(tests.TestCase):
+    def setUp(self):
+        super(BasePluginTestCase, self).setUp()
+        self.plugin = BasePluginDummy()
+
+    def test__is_project_allowed(self):
+        # No project restrictions
+        project_id = "0ac67a48-e65c-11eb-ba80-0242ac130004"
+        resource = {}
+        self.assertTrue(self.plugin.is_project_allowed(project_id, resource))
+
+        # Single project restriction
+        resource = {
+            "authorized_projects": "0ac67a48-e65c-11eb-ba80-0242ac130004"
+        }
+        project_id = "0ac67a48-e65c-11eb-ba80-0242ac130004"
+        self.assertTrue(self.plugin.is_project_allowed(project_id, resource))
+        project_id = "6bd9356e-e65c-11eb-ba80-0242ac130004"
+        self.assertFalse(self.plugin.is_project_allowed(project_id, resource))
+
+        resource = {
+            "authorized_projects": "0ac67a48-e65c-11eb-ba80-0242ac130004,"
+                                   "6bd9356e-e65c-11eb-ba80-0242ac130004"
+        }
+        project_id = "0ac67a48-e65c-11eb-ba80-0242ac130004"
+        self.assertTrue(self.plugin.is_project_allowed(project_id, resource))
+        project_id = "6bd9356e-e65c-11eb-ba80-0242ac130004"
+        self.assertTrue(self.plugin.is_project_allowed(project_id, resource))
+        project_id = "923cf8d0-e65c-11eb-ba80-0242ac130004"
+        self.assertFalse(self.plugin.is_project_allowed(project_id, resource))


### PR DESCRIPTION
Devices are filtered out based on the project id when computing allocation candidates. Any device with the `authorized_projects` extra capability is treated as restricted, and will not show up in the list of allocation candidates.