### PR TITLE
get context from trust for end_lease

### DIFF
--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -692,7 +692,11 @@ class ManagerService(service_utils.RPCServer):
         lease = self.get_lease(lease_id)
         allocations = self._existing_allocations(lease['reservations'])
         try:
-            self.enforcement.on_end(context.current(), lease, allocations)
+            # no rpc call with authentication context, i.e.
+            # context.current() doesn't work here.
+            # so need to get context from the lease trust.
+            self.enforcement.on_end(trusts.create_ctx_from_trust(
+                lease['trust_id']), lease, allocations)
         except Exception as e:
             LOG.error(e)
 

--- a/blazar/utils/trusts.py
+++ b/blazar/utils/trusts.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
-
 from oslo_config import cfg
 
 from blazar import context
 from blazar.utils.openstack import keystone
+import functools
+
 
 CONF = cfg.CONF
 
@@ -58,7 +58,9 @@ def create_ctx_from_trust(trust_id):
         project_id=session.get_project_id(),
         service_catalog=(
             ctx.service_catalog or
-            session.auth.get_auth_ref().service_catalog),
+            session.auth.get_auth_ref(
+                session=session
+            ).service_catalog.normalize_catalog()),
         request_id=ctx.request_id,
         global_request_id=ctx.global_request_id
     )


### PR DESCRIPTION
when lease terminates (not deleted by user), there is no rpc call
with authentication context. therefore, enforcement on_end fails
with error "service identity not found". no enforcement filters
will be executed. this fix gets the context from the lease trust.