### PR TITLE
Add 'extras' field when getting allocations

### DIFF
--- a/blazar/db/sqlalchemy/utils.py
+++ b/blazar/db/sqlalchemy/utils.py
@@ -280,6 +280,15 @@ def get_reservation_allocations_by_device_ids(device_ids, start_date, end_date,
     return reservations
 
 
+def get_user_ids_for_lease_ids(lease_ids):
+    session = get_session()
+
+    leases_query = (session.query(models.Lease.id, models.Lease.user_id)
+        .filter(models.Lease.id.in_(lease_ids)))
+
+    return leases_query.all()
+
+
 def get_plugin_reservation(resource_type, resource_id):
     if resource_type == host_plugin.RESOURCE_TYPE:
         return api.host_reservation_get(resource_id)

--- a/blazar/db/utils.py
+++ b/blazar/db/utils.py
@@ -163,3 +163,6 @@ def get_reserved_periods(resource_id, start_date, end_date, duration,
     """Returns a list of reserved periods."""
     return IMPL.get_reserved_periods(resource_id, start_date, end_date,
                                      duration, resource_type=resource_type)
+
+def get_user_ids_for_lease_ids(lease_ids):
+    return IMPL.get_user_ids_for_lease_ids(lease_ids)

--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -52,7 +52,10 @@ manager_opts = [
                default=1,
                min=0,
                max=50,
-               help='Number of times to retry an event action.')
+               help='Number of times to retry an event action.'),
+    cfg.ListOpt('extras',
+                default=[],
+                help='What extra information to include with allocations.'),
 ]
 
 CONF = cfg.CONF

--- a/blazar/plugins/base.py
+++ b/blazar/plugins/base.py
@@ -17,6 +17,9 @@ import abc
 import collections
 
 from blazar.db import api as db_api
+from blazar.db import utils as db_utils
+from blazar.i18n import _
+from blazar.utils.openstack import keystone
 from oslo_config import cfg
 from oslo_log import log as logging
 import six
@@ -158,6 +161,29 @@ class BasePlugin(object):
             return project_id in authorized_projects
         return True
 
+    def add_extra_allocation_info(self, resource_allocations):
+        """Add extra information to allocations (to show in calendar)"""
+        extras = CONF.manager.extras
+        for allocs in resource_allocations.values():
+            for alloc in allocs:
+                alloc["extras"] = []
+        if "name" in extras:
+            ids = []
+            for allocations in resource_allocations.values():
+                for alloc in allocations:
+                    ids.append(alloc["lease_id"])
+            items = db_utils.get_user_ids_for_lease_ids(ids)
+            keystoneclient = keystone.BlazarKeystoneClient()
+            lease_to_name = dict()
+            for lease_id, user_id in items:
+                user = keystoneclient.users.get(user_id)
+                lease_to_name[lease_id] = user.name
+
+            for allocations in resource_allocations.values():
+                for alloc in allocations:
+                    alloc["extras"] = [
+                        (_("Reserved by"), lease_to_name[alloc["lease_id"]]),
+                    ]
 
 @six.add_metaclass(abc.ABCMeta)
 class BaseMonitorPlugin():

--- a/blazar/plugins/base.py
+++ b/blazar/plugins/base.py
@@ -18,7 +18,6 @@ import collections
 
 from blazar.db import api as db_api
 from blazar.db import utils as db_utils
-from blazar.i18n import _
 from blazar.utils.openstack import keystone
 from oslo_config import cfg
 from oslo_log import log as logging
@@ -166,7 +165,7 @@ class BasePlugin(object):
         extras = CONF.manager.extras
         for allocs in resource_allocations.values():
             for alloc in allocs:
-                alloc["extras"] = []
+                alloc["extras"] = {}
         if "name" in extras:
             ids = []
             for allocations in resource_allocations.values():
@@ -174,16 +173,16 @@ class BasePlugin(object):
                     ids.append(alloc["lease_id"])
             items = db_utils.get_user_ids_for_lease_ids(ids)
             keystoneclient = keystone.BlazarKeystoneClient()
+            users = keystoneclient.users.list()
+            user_map = { user.id: user for user in users }
             lease_to_name = dict()
             for lease_id, user_id in items:
-                user = keystoneclient.users.get(user_id)
+                user = user_map[user_id]
                 lease_to_name[lease_id] = user.name
 
             for allocations in resource_allocations.values():
                 for alloc in allocations:
-                    alloc["extras"] = [
-                        (_("Reserved by"), lease_to_name[alloc["lease_id"]]),
-                    ]
+                    alloc["extras"]["name"] = lease_to_name[alloc["lease_id"]]
 
 @six.add_metaclass(abc.ABCMeta)
 class BaseMonitorPlugin():

--- a/blazar/plugins/devices/device_plugin.py
+++ b/blazar/plugins/devices/device_plugin.py
@@ -30,7 +30,6 @@ from blazar.manager import exceptions as manager_ex
 from blazar.plugins import base
 from blazar.plugins import devices as plugin
 from blazar.utils import plugins as plugins_utils
-from blazar.utils.openstack import keystone
 from blazar.utils.openstack import placement
 from oslo_log import log as logging
 from random import shuffle
@@ -468,33 +467,10 @@ class DevicePlugin(base.BasePlugin):
         devices_allocations = self.query_device_allocations(devices_id_list,
                                                             **options)
 
-        for _, allocs in devices_allocations.items():
-            for alloc in allocs:
-                alloc["extras"] = []
-        self.get_extra_allocation_info(devices_allocations)
+        self.add_extra_allocation_info(devices_allocations)
 
         return [{"resource_id": device, "reservations": allocs}
                 for device, allocs in devices_allocations.items()]
-
-    def get_extra_allocation_info(self, devices_allocations):
-        # TODO Get a config option here
-        ids = []
-        for device, allocations in devices_allocations.items():
-            for alloc in allocations:
-                ids.append(alloc["lease_id"])
-        items = db_utils.get_user_ids_for_lease_ids(ids)
-        keystoneclient = keystone.BlazarKeystoneClient()
-        lease_to_name = dict()
-        for lease_id, user_id in items:
-            user = keystoneclient.users.get(user_id)
-            lease_to_name[lease_id] = user.name
-
-        for device, allocations in devices_allocations.items():
-            for alloc in allocations:
-                alloc["extras"] = [
-                    (_("Reserved by"), lease_to_name[alloc["lease_id"]]),
-                ]
-
 
     def get_allocations(self, device_id, query, detail=False):
         options = self.get_query_options(query, QUERY_TYPE_ALLOCATION)

--- a/blazar/plugins/devices/device_plugin.py
+++ b/blazar/plugins/devices/device_plugin.py
@@ -25,7 +25,6 @@ from blazar import status
 from blazar.db import api as db_api
 from blazar.db import exceptions as db_ex
 from blazar.db import utils as db_utils
-from blazar.i18n import _
 from blazar.manager import exceptions as manager_ex
 from blazar.plugins import base
 from blazar.plugins import devices as plugin
@@ -466,9 +465,7 @@ class DevicePlugin(base.BasePlugin):
         options['detail'] = detail
         devices_allocations = self.query_device_allocations(devices_id_list,
                                                             **options)
-
         self.add_extra_allocation_info(devices_allocations)
-
         return [{"resource_id": device, "reservations": allocs}
                 for device, allocs in devices_allocations.items()]
 

--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -485,6 +485,7 @@ class NetworkPlugin(base.BasePlugin):
 
         network_allocations = self.query_network_allocations(network_id_list,
                                                              **options)
+        self.add_extra_allocation_info(network_allocations)
         return [{"resource_id": network, "reservations": allocs}
                 for network, allocs in network_allocations.items()]
 

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -538,6 +538,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         options['detail'] = detail
         hosts_allocations = self.query_host_allocations(hosts_id_list,
                                                         **options)
+        self.add_extra_allocation_info(hosts_allocations)
         return [{"resource_id": host, "reservations": allocs}
                 for host, allocs in hosts_allocations.items()]
 


### PR DESCRIPTION
This field is a list of extra information to include with allocations
so they can be used by the calendar. This should probably be configured
by the config file, or something.

Initially, the only extra is `Reserved by` which is associated with the name
of the user who created the allocation.