### PR TITLE
Add default resource properties

### DIFF
--- a/blazar/plugins/devices/device_plugin.py
+++ b/blazar/plugins/devices/device_plugin.py
@@ -49,6 +49,10 @@ plugin_opts = [
                help='The minimum interval [minutes] between the end of a '
                'lease and the start of the next lease for the same '
                'device. This interval is used for cleanup.'),
+    cfg.StrOpt('default_resource_properties',
+                default='',
+                help='Default resource_properties when creating a lease of '
+                     'this type.'),
 ]
 
 plugin_opts.extend(monitor.monitor_opts)
@@ -526,6 +530,11 @@ class DevicePlugin(base.BasePlugin):
         return device_allocations
 
     def allocation_candidates(self, values):
+        if not values.get('resource_properties', ''):
+            values['resource_properties'] = CONF[
+                plugin.RESOURCE_TYPE
+            ].default_resource_properties
+
         self._check_params(values)
 
         device_ids = self._matching_devices(

--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -32,7 +32,18 @@ from blazar.utils.openstack import ironic
 from blazar.utils.openstack import neutron
 from blazar.utils import plugins as plugins_utils
 
+
+plugin_opts = [
+    cfg.StrOpt('default_resource_properties',
+                default='',
+                help='Default resource_properties when creating a lease of '
+                     'this type.'),
+
+]
+
+
 CONF = cfg.CONF
+CONF.register_opts(plugin_opts, group=plugin.RESOURCE_TYPE)
 LOG = logging.getLogger(__name__)
 
 before_end_options = ['', 'snapshot', 'default', 'email']
@@ -538,6 +549,11 @@ class NetworkPlugin(base.BasePlugin):
         return network_allocations
 
     def allocation_candidates(self, values):
+        if not values.get('resource_properties', ''):
+            values['resource_properties'] = CONF[
+                plugin.RESOURCE_TYPE
+            ].default_resource_properties
+
         self._check_params(values)
 
         network_ids = self._matching_networks(

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -47,6 +47,11 @@ plugin_opts = [
                default='',
                help='Actions which we will be taken before the end of '
                     'the lease'),
+    cfg.StrOpt('default_resource_properties',
+                default='',
+                help='Default resource_properties when creating a lease of '
+                     'this type.'),
+
 ]
 
 plugin_opts.extend(monitor.monitor_opts)
@@ -558,6 +563,11 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         return host_allocations
 
     def allocation_candidates(self, values):
+        if not values.get('resource_properties', ''):
+            values['resource_properties'] = CONF[
+                plugin.RESOURCE_TYPE
+            ].default_resource_properties
+
         self._check_params(values)
 
         host_ids = self._matching_hosts(
@@ -636,6 +646,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
 
         if 'hypervisor_properties' not in values:
             raise manager_ex.MissingParameter(param='hypervisor_properties')
+
         if 'resource_properties' not in values:
             raise manager_ex.MissingParameter(param='resource_properties')
 


### PR DESCRIPTION
Adds config key `default_resource_properties` to each plugins config section, allowing this string to be set. Note
that due to the config language, something like `["=", "$node_type", "compute_skylake"]` must be escaped to `["=", "\$node_type", "compute_skylake"]`