### PR TITLE
Fix lease-update bug

### DIFF
--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -493,8 +493,9 @@ class ManagerService(service_utils.RPCServer):
 
         if reservations:
             new_reservations = reservations
+            values["project_id"] = lease["project_id"]
             new_allocs = self._allocation_candidates(values,
-                                                     existing_reservations)
+                                                     new_reservations)
         else:
             # User is not updating reservation parameters, e.g., is only
             # adjusting lease start/end dates.


### PR DESCRIPTION
This fixes the error where `project_id` is missing in `_allocation_candidates`, and with checking enforcement. Since this passes in the "new" (meaning updated) reservations, you need to include all of the checked parameters, for instance:
``` 
--reservation "id=fc95d4f3-783f-4279-b6dc-34d7500eb82f,resource_type=physical:host,min=2,max=2,resource_properties=[],hypervisor_properties=[]"
```
Without this fix, enforcement is not running correctly. I was not able to test adding hosts while a lease is active.