### PR TITLE
Prevent reallocating a host with servers

### DIFF
--- a/blazar/api/v1/devices/service.py
+++ b/blazar/api/v1/devices/service.py
@@ -71,7 +71,7 @@ class API(object):
     @policy.authorize('devices', 'reallocate')
     def reallocate(self, device_id, data):
         """Exchange device from allocations."""
-        return self.plugin.reallocate(device_id, data)
+        return self.plugin.reallocate_device(device_id, data)
 
     @policy.authorize('devices', 'get_allocations')
     def list_allocations(self, query):

--- a/blazar/api/v1/oshosts/service.py
+++ b/blazar/api/v1/oshosts/service.py
@@ -97,7 +97,7 @@ class API(object):
     @policy.authorize('oshosts', 'reallocate')
     def reallocate(self, host_id, data):
         """Exchange host from allocations."""
-        return self.plugin.reallocate(host_id, data)
+        return self.plugin.reallocate_computehost(host_id, data)
 
     @policy.authorize('oshosts', 'get_resource_properties')
     def list_resource_properties(self, query):

--- a/blazar/manager/exceptions.py
+++ b/blazar/manager/exceptions.py
@@ -69,8 +69,11 @@ class MultipleHostsFound(exceptions.BlazarException):
     msg_fmt = _("Multiple Hosts found for pattern '%(host)s'")
 
 
-class HostHavingServers(exceptions.BlazarException):
+class ResourceBusy(exceptions.BlazarException):
     code = 409
+
+
+class HostHavingServers(ResourceBusy):
     msg_fmt = _("Servers [%(servers)s] found for host %(host)s")
 
 

--- a/blazar/plugins/monitor.py
+++ b/blazar/plugins/monitor.py
@@ -21,6 +21,7 @@ import six
 
 import abc
 from blazar.plugins import base
+from blazar.manager import exceptions as manager_ex
 from blazar import status
 from oslo_log import log as logging
 
@@ -154,17 +155,23 @@ class GeneralMonitorPlugin(base.BaseMonitorPlugin):
 
             for allocation in self.filter_allocations(reservation,
                                                       resource_ids):
-                if self._reallocate(allocation):
-                    if reservation['status'] == status.reservation.ACTIVE:
+                try:
+                    if self._reallocate(allocation):
+                        if reservation['status'] == status.reservation.ACTIVE:
+                            if reservation_id not in reservation_flags:
+                                reservation_flags[reservation_id] = {}
+                            reservation_flags[reservation_id].update(
+                                {'resources_changed': True})
+                    else:
                         if reservation_id not in reservation_flags:
                             reservation_flags[reservation_id] = {}
                         reservation_flags[reservation_id].update(
-                            {'resources_changed': True})
-                else:
-                    if reservation_id not in reservation_flags:
-                        reservation_flags[reservation_id] = {}
-                    reservation_flags[reservation_id].update(
-                        {'missing_resources': True})
+                            {'missing_resources': True})
+                except manager_ex.HostHavingServers:
+                    LOG.info(
+                        "Cannot heal reservation %s, found servers",
+                        reservation["id"]
+                    )
 
         return reservation_flags
 

--- a/blazar/plugins/monitor.py
+++ b/blazar/plugins/monitor.py
@@ -20,8 +20,8 @@ from oslo_config import cfg
 import six
 
 import abc
-from blazar.plugins import base
 from blazar.manager import exceptions as manager_ex
+from blazar.plugins import base
 from blazar import status
 from oslo_log import log as logging
 
@@ -167,7 +167,7 @@ class GeneralMonitorPlugin(base.BaseMonitorPlugin):
                             reservation_flags[reservation_id] = {}
                         reservation_flags[reservation_id].update(
                             {'missing_resources': True})
-                except manager_ex.HostHavingServers:
+                except manager_ex.ResourceBusy:
                     LOG.info(
                         "Cannot heal reservation %s, found servers",
                         reservation["id"]

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -244,6 +244,15 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         # Remove the old host from the aggregate.
         if reservation['status'] == status.reservation.ACTIVE:
             host = db_api.host_get(allocation['compute_host_id'])
+
+            servers = self.nova.servers.list(search_opts={
+                "node": host['hypervisor_hostname'], "all_tenants": 1})
+            if len(servers) != 0:
+                raise manager_ex.HostHavingServers(
+                    servers=[s.name for s in servers],
+                    host=host['hypervisor_hostname']
+                )
+
             pool.remove_computehost(h_reservation['aggregate_id'],
                                     host['hypervisor_hostname'])
 


### PR DESCRIPTION
This stops the reallocate command from reallocating a host with
servers, and a "failed" host with a server will be ignored by the
monitor plugin.

While testing, I encountered a bug with the API method called for
reallocate, which is included here as well.