### PR TITLE
Revert constraints back to train

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,11 +18,11 @@ oslo.i18n>=3.15.3 # Apache-2.0
 oslo.log>=3.36.0 # Apache-2.0
 oslo.messaging>=5.29.0 # Apache-2.0
 oslo.middleware>=3.31.0 # Apache-2.0
-oslo.policy>=3.6.0 # Apache-2.0
+oslo.policy>=1.30.0 # Apache-2.0
 oslo.serialization!=2.19.1,>=2.18.0 # Apache-2.0
 oslo.service>=1.34.0 # Apache-2.0
-oslo.upgradecheck>=1.3.0 # Apache-2.0
-oslo.utils>=4.5.0 # Apache-2.0
+oslo.upgradecheck>=0.1.0 # Apache-2.0
+oslo.utils>=3.33.0 # Apache-2.0
 python-ironicclient>=1.11.0 # Apache-2.0
 python-neutronclient>=6.0.0 # Apache-2.0
 python-novaclient>=9.1.0 # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ ignore_basepython_conflict = True
 basepython = python3
 usedevelop = True
 allowlist_externals = rm
-install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/xena} {opts} {packages}
+install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train} {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
        -r{toxinidir}/requirements.txt
 setenv = VIRTUAL_ENV={envdir}
@@ -40,7 +40,7 @@ commands = {posargs}
 [testenv:docs]
 basepython = python3
 deps =
-    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/xena}
+    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands =


### PR DESCRIPTION
Since our images use the train `upper-constraints.txt`, they cannot be built with the upstream `requirements.txt`. 

These requirements were updated as a goal to deprecate `policy.json`:
https://opendev.org/openstack/blazar/commit/3f1c1ed3125445387309e59cfe243c824fbe7853