### PR TITLE
Fix typo in max reservation exception filter

### DIFF
--- a/blazar/enforcement/filters/max_lease_duration_filter.py
+++ b/blazar/enforcement/filters/max_lease_duration_filter.py
@@ -95,7 +95,7 @@ class MaxLeaseDurationFilter(base_filter.BaseFilter):
             update_at = datetime.utcnow()
 
             if update_at < min_window:
-                raise enforcement_ex.MaxReservationUpdateWindowException(
+                raise enforcement_ex.MaxLeaseDurationException(
                     extension_window=(self.reservation_extension_window))
 
             start_date = current_lease_values['end_date']


### PR DESCRIPTION
I missed this when merging upstream. The bug generates the wrong error message, and this fixes it.