### PR TITLE
Fix floating ip retry error

### DIFF
--- a/blazar/plugins/floatingips/floatingip_plugin.py
+++ b/blazar/plugins/floatingips/floatingip_plugin.py
@@ -31,8 +31,15 @@ from blazar import status
 from blazar.utils.openstack import neutron
 from blazar.utils import plugins as plugins_utils
 
+plugin_opts = [
+    cfg.BoolOpt('retry_allocation_without_defaults',
+                default=False,
+                help='Whether an allocation should be retried on failure '
+                     'without the default properties'),
+]
 
 CONF = cfg.CONF
+CONF.register_opts(plugin_opts, group=plugin.RESOURCE_TYPE)
 LOG = logging.getLogger(__name__)
 
 QUERY_TYPE_ALLOCATION = 'allocation'


### PR DESCRIPTION
Since there were no conf opts, an error was generated when the manager service would run the code to retry without defaults when the floating IP reservation failed. This generates a generic 500 error message, rather than "not enough floating ips".

This adds a config option, which stops the code from failing when getting the config section for floating IPs. Whether this option is True or False, no behavior is changed, since the floating IP plugin doesn't use resource properties anyway: `allocation_candidates` is empty in both cases.