### PR TITLE
Fix lease update duration error message

### DIFF
--- a/blazar/enforcement/filters/max_lease_duration_filter.py
+++ b/blazar/enforcement/filters/max_lease_duration_filter.py
@@ -95,7 +95,7 @@ class MaxLeaseDurationFilter(base_filter.BaseFilter):
             update_at = datetime.utcnow()
 
             if update_at < min_window:
-                raise enforcement_ex.MaxLeaseDurationException(
+                raise enforcement_ex.MaxLeaseUpdateWindowException(
                     extension_window=(self.reservation_extension_window))
 
             start_date = current_lease_values['end_date']


### PR DESCRIPTION
Lease updates which put their duration outside of the acceptable window
would raise an incorrect exception, which would include format codes in
the error message. This change will make the error message clearer to
users.
