### PR TITLE
Forbid setting bad extra capabilities

### DIFF
--- a/blazar/db/exceptions.py
+++ b/blazar/db/exceptions.py
@@ -50,5 +50,6 @@ class BlazarDBInvalidExtraCapability(BlazarDBException):
     msg_fmt = _('%(property_name)s does not exist for resource type '
                 '%(resource_type)s.')
 
+
 class BlazarDBForbiddenExtraCapability(BlazarDBException):
     msg_fmt = _('%(property_name)s cannot be set as an extra capability')

--- a/blazar/db/exceptions.py
+++ b/blazar/db/exceptions.py
@@ -49,3 +49,6 @@ class BlazarDBExtraCapabilitiesNotEnabled(BlazarDBException):
 class BlazarDBInvalidExtraCapability(BlazarDBException):
     msg_fmt = _('%(property_name)s does not exist for resource type '
                 '%(resource_type)s.')
+
+class BlazarDBForbiddenExtraCapability(BlazarDBException):
+    msg_fmt = _('%(property_name)s cannot be set as an extra capability')

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -35,6 +35,7 @@ EXTRA_CAPABILITY_MODELS = {
     'network': models.NetworkSegmentExtraCapability,
     'device': models.DeviceExtraCapability,
 }
+FORBIDDEN_EXTRA_CAPABILITY_NAMES = ["id", "reservable"]
 
 LOG = logging.getLogger(__name__)
 
@@ -2073,12 +2074,15 @@ def _resource_property_get_or_create(session, resource_type, capability_name):
 
     if resource_property:
         return resource_property
-    else:
+    elif capability_name not in FORBIDDEN_EXTRA_CAPABILITY_NAMES:
         rp_values = {
             'resource_type': resource_type,
             'capability_name': capability_name}
 
         return resource_property_create(rp_values)
+    else:
+        raise db_exc.BlazarDBForbiddenExtraCapability(
+            property_name=capability_name)
 
 
 def resource_property_get_or_create(resource_type, capability_name):

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -2069,20 +2069,21 @@ def resource_property_update(resource_type, property_name, values):
 
 
 def _resource_property_get_or_create(session, resource_type, capability_name):
+    if capability_name in FORBIDDEN_EXTRA_CAPABILITY_NAMES:
+        raise db_exc.BlazarDBForbiddenExtraCapability(
+            property_name=capability_name)
+
     resource_property = _resource_property_get(
         session, resource_type, capability_name)
 
     if resource_property:
         return resource_property
-    elif capability_name not in FORBIDDEN_EXTRA_CAPABILITY_NAMES:
+    else:
         rp_values = {
             'resource_type': resource_type,
             'capability_name': capability_name}
 
         return resource_property_create(rp_values)
-    else:
-        raise db_exc.BlazarDBForbiddenExtraCapability(
-            property_name=capability_name)
 
 
 def resource_property_get_or_create(resource_type, capability_name):


### PR DESCRIPTION
Specifically, `id` and `reservable` are not allowed to be created for any model.