### PR TITLE
storage vlan reservation

### DIFF
--- a/blazar/manager/exceptions.py
+++ b/blazar/manager/exceptions.py
@@ -118,6 +118,10 @@ class CantAddExtraCapability(exceptions.BlazarException):
     code = 409
     msg_fmt = _("Can't add extracapabilities %(keys)s to Host %(host)s")
 
+class ExtraCapabilityNotFound(exceptions.BlazarException):
+    code = 404
+    msg_fmt = _("Capability %(keys)s not found on resource %(resource)s")
+
 
 class EndpointsNotFound(exceptions.NotFound):
     code = 404

--- a/blazar/manager/exceptions.py
+++ b/blazar/manager/exceptions.py
@@ -267,6 +267,11 @@ class NetworkCreationFailed(exceptions.BlazarException):
                 "%(msg)s")
 
 
+class NetworkExtraOnStartFailed(exceptions.BlazarException):
+    msg_fmt = _("Failed on extra on start steps for reservation %(id)s. "
+                "%(msg)s")
+
+
 class NetworkDeletionFailed(exceptions.BlazarException):
     msg_fmt = _("Failed to delete network %(network_id)s for reservation "
                 "%(reservation_id)s")

--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -17,9 +17,11 @@
 import datetime
 from random import shuffle
 
+from keystoneauth1 import exceptions as keystone_excptions
 from neutronclient.common import exceptions as neutron_ex
 from oslo_config import cfg
 from oslo_log import log as logging
+from stevedore import named
 
 from blazar.db import api as db_api
 from blazar.db import exceptions as db_ex
@@ -46,7 +48,9 @@ plugin_opts = [
                 default=True,
                 help='Whether an allocation should be retried on failure '
                      'without the default properties'),
-
+    cfg.ListOpt('usage_type_plugins',
+                default=[],
+                help='All plugins to use'),
 ]
 
 
@@ -57,6 +61,34 @@ LOG = logging.getLogger(__name__)
 before_end_options = ['', 'snapshot', 'default', 'email']
 
 QUERY_TYPE_ALLOCATION = 'allocation'
+
+
+def _get_plugins():
+    """Return dict of resource-plugin class pairs."""
+    plugins = {}
+
+    extension_manager = named.NamedExtensionManager(
+        namespace='blazar.network.usage.type.plugins',
+        names=CONF.network.usage_type_plugins,
+        invoke_on_load=False
+    )
+
+    for ext in extension_manager.extensions:
+        try:
+            plugin_obj = ext.plugin()
+        except Exception as e:
+            LOG.warning("Could not load {0} plugin "
+                        "for resource type {1} '{2}'".format(
+                            ext.name, ext.plugin.usage_type, e))
+        else:
+            if plugin_obj.usage_type in plugins:
+                msg = ("You have provided several plugins for "
+                       "one usage type in configuration file. "
+                       "Please set one plugin per usage type.")
+                raise manager_ex.PluginConfigurationError(error=msg)
+
+        plugins[plugin_obj.usage_type] = plugin_obj
+    return plugins
 
 
 class NetworkPlugin(base.BasePlugin):
@@ -70,6 +102,11 @@ class NetworkPlugin(base.BasePlugin):
 
     def __init__(self):
         super(NetworkPlugin, self).__init__()
+        self.plugins = _get_plugins()
+        self.periodic_tasks = []
+        for plugin in self.plugins.values():
+            if hasattr(plugin, "periodic_tasks"):
+                self.periodic_tasks.extend(plugin.periodic_tasks)
 
     def filter_networks_by_reservation(self, networks, start_date, end_date):
         free = []
@@ -166,7 +203,7 @@ class NetworkPlugin(base.BasePlugin):
 
         for allocation in db_api.network_allocation_get_all_by_values(
                 reservation_id=reservation_id):
-            network_segment = db_api.network_get(allocation['network_id'])
+            network_segment = self.get_network(allocation['network_id'])
             network_type = network_segment['network_type']
             physical_network = network_segment['physical_network']
             segment_id = network_segment['segment_id']
@@ -199,6 +236,20 @@ class NetworkPlugin(base.BasePlugin):
                                                        id=reservation_id,
                                                        msg=str(e))
 
+            # extra steps for the usage type
+            usage_type = network_segment.get("usage_type", None)
+            if usage_type:
+                try:
+                    self.plugins[usage_type].perform_extra_on_start_steps(
+                        network_segment, network
+                    )
+                except Exception as e:
+                    LOG.error("Extra on start steps failed: %s", e)
+                    raise manager_ex.NetworkExtraOnStartFailed(
+                        id=reservation_id,
+                        msg=str(e)
+                    )
+
     def delete_port(self, neutron_client, ironic_client, port):
         if port['binding:vnic_type'] == 'baremetal':
             node = port.get('binding:host_id')
@@ -228,7 +279,11 @@ class NetworkPlugin(base.BasePlugin):
             return
 
         neutron_client = neutron.BlazarNeutronClient(trust_id=trust_id)
-        ironic_client = ironic.BlazarIronicClient()
+        ironic_client = None
+        try:
+            ironic_client = ironic.BlazarIronicClient()
+        except keystone_excptions.catalog.EndpointNotFound:
+            LOG.exception("The endpoint for Ironic not found")
 
         try:
             neutron_client.show_network(network_id)

--- a/blazar/plugins/networks/storage_plugin.py
+++ b/blazar/plugins/networks/storage_plugin.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+#
+# Author: Chameleon Cloud
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from blazar.db import api as db_api
+from blazar.db import utils as db_utils
+from blazar.manager import exceptions as manager_ex
+from blazar.utils.openstack import manila
+from blazar.utils.openstack import neutron
+import datetime
+from oslo_config import cfg
+from oslo_context import context
+from oslo_log import log as logging
+from oslo_service import periodic_task
+
+opts = [
+    cfg.StrOpt('external_ganesha_network',
+               default='filesystem-ganesha',
+               help='External network name for NFS-Ganesha'),
+    cfg.IntOpt('set_manila_share_access_rules_interval',
+               default=5*60,
+               help='Set access rules for all manila shares every N seconds.'
+                    'If this number is negative the periodic task will be '
+                    'disabled.'),
+    cfg.StrOpt('ceph_nfs_share_type',
+               default='default_share_type',
+               help='The Ceph NFS share type'),
+]
+
+CONF = cfg.CONF
+CONF.register_opts(opts, group="network_storage")
+LOG = logging.getLogger(__name__)
+
+STORAGE_ROUTER_NAME = "storage_router_{network_segment_id}"
+
+
+class StoragePlugin():
+    """Plugin for storage usage type."""
+    usage_type = "storage"
+
+    def __init__(self):
+        super(StoragePlugin, self).__init__()
+        self.neutron_client = neutron.BlazarNeutronClient()
+        self.manila_client = manila.BlazarManilaClient()
+        external_ganesha_network = self.neutron_client.list_networks(
+            name=CONF.network_storage.external_ganesha_network
+        ).get("networks")
+        self.external_ganesha_network = next(
+            iter(external_ganesha_network), None
+        )
+        if not self.external_ganesha_network:
+            raise manager_ex.NetworkNotFound(
+                network=CONF.network_storage.external_ganesha_network
+            )
+        self.periodic_tasks = [self._set_manila_share_access_rules]
+
+    def perform_extra_on_start_steps(self, network_segment, neutron_network):
+        neutron_network = neutron_network["network"]
+        router = None
+        try:
+            # create a router with the owner of service project
+            router_body = {
+                    "router": {
+                        "name": STORAGE_ROUTER_NAME.format(
+                            network_segment_id=network_segment["id"]
+                        ),
+                        "admin_state_up": True,
+                        "external_gateway_info": {
+                            "network_id": self.external_ganesha_network["id"],
+                            "enable_snat": False,
+                        },
+                    }
+            }
+            router = self.neutron_client.create_router(body=router_body)
+            # create a subnet (predefined CIDR) with the reserved network
+            subnet_body = {
+                    "subnet": {
+                        "name": f"{neutron_network['name']}-subnet",
+                        "cidr": network_segment["subnet_cidr"],
+                        "network_id": neutron_network["id"],
+                        "ip_version": 4,
+                        "project_id": neutron_network["project_id"],
+                    }
+            }
+            subet = self.neutron_client.create_subnet(body=subnet_body)
+            # share the network with serivce project
+            rbac_policy_body = {
+                "rbac_policy": {
+                    "object_type": "network",
+                    "action": "access_as_shared",
+                    "target_tenant": CONF.os_admin_project_name,
+                    "object_id": neutron_network["id"],
+                }
+            }
+            self.neutron_client.create_rbac_policy(
+                rbac_policy_body
+            )
+            # add the subnet to the router
+            interface_body = {
+                'subnet_id': subet["subnet"]["id"],
+            }
+            self.neutron_client.add_interface_router(
+                router=router["router"]["id"], body=interface_body
+            )
+        except Exception as e:
+            self.neutron_client.delete_network(neutron_network["id"])
+            if router:
+                self.neutron_client.delete_router(router["router"]["id"])
+            raise e
+
+    def _get_storage_networks(self):
+        networks = db_api.network_list()
+        storage_networks = []
+        for network_segment in networks:
+            network_segment_id = network_segment["id"]
+            network = db_api.network_get(network_segment_id)
+            raw_extra_capabilities = (
+                db_api.network_extra_capability_get_all_per_network(
+                    network_segment_id
+                ))
+            extra_capabilities = {}
+            for capability, capability_name in raw_extra_capabilities:
+                key = capability_name
+                extra_capabilities[key] = capability.capability_value
+            if ("usage_type" in extra_capabilities and
+                    extra_capabilities["usage_type"] == self.usage_type):
+                network.update(extra_capabilities)
+                storage_networks.append(network)
+        return storage_networks
+
+    @periodic_task.periodic_task(
+        spacing=CONF.network_storage.set_manila_share_access_rules_interval,
+        run_immediately=True
+    )
+    def _set_manila_share_access_rules(self, manager_obj, context):
+        # get all available shares
+        shares = self.manila_client.shares.list(
+            search_opts={
+                "all_tenants": 1,
+                "share_type": CONF.network_storage.ceph_nfs_share_type,
+                # "status": "available",
+            }
+        )
+        # get all storage network reservations
+        storage_networks = self._get_storage_networks()
+        storage_vlan_cidr = {n["id"]: n["subnet_cidr"]
+                             for n in storage_networks}
+        start = datetime.datetime.utcnow()
+        end = start
+        reservations = db_utils.get_reservation_allocations_by_network_ids(
+            list(storage_vlan_cidr.keys()), start, end
+        )
+        project_reservations = {}
+        for res in reservations:
+            pid = res["project_id"]
+            if pid not in project_reservations:
+                project_reservations[pid] = []
+            project_reservations[pid].extend(res["network_ids"])
+
+        for share in shares:
+            try:
+                proj = share.project_id
+                access_rules = self.manila_client.shares.access_list(share.id)
+                existing_cidr_to_id = {
+                    rule.access_to: rule.id for rule in access_rules
+                    if rule.access_level == "rw"
+                }
+                existing_cidrs = list(existing_cidr_to_id.keys())
+                new_cidrs = []
+                if proj in project_reservations:
+                    for network_id in project_reservations[proj]:
+                        new_cidrs.append(storage_vlan_cidr[network_id])
+                cidrs_to_add = set(new_cidrs).difference(existing_cidrs)
+                cidrs_to_delete = set(existing_cidrs).difference(new_cidrs)
+                for cidr in cidrs_to_add:
+                    self.manila_client.shares.allow(
+                        share.id, "ip", cidr, "rw"
+                    )
+                for cidr in cidrs_to_delete:
+                    self.manila_client.share_access_rules.delete(
+                        existing_cidr_to_id[cidr]
+                    )
+                # all users should have ro access to a public share
+                existing_ro_cidrs = {
+                    rule.access_to: rule.id for rule in access_rules
+                    if rule.access_level == "ro"
+                }
+                if share.is_public and not existing_ro_cidrs:
+                    self.manila_client.shares.allow(
+                        share.id, "ip", "0.0.0.0/0", "ro"
+                    )
+                if not share.is_public and existing_ro_cidrs:
+                    for cidr, rule_id in existing_ro_cidrs:
+                        self.manila_client.share_access_rules.delete(
+                            rule_id
+                        )
+            except Exception as e:
+                LOG.exception(
+                    f"Failed to manage access rules for share {share.id}"
+                )

--- a/blazar/utils/openstack/manila.py
+++ b/blazar/utils/openstack/manila.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2020 University of Chicago
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from oslo_config import cfg
+
+from blazar.utils.openstack import base
+from oslo_log import log as logging
+from manilaclient import client as manila_client
+
+
+manila_opts = [
+    cfg.StrOpt(
+        'manila_api_version',
+        default='2',
+        help='Manila API version'),
+    cfg.StrOpt(
+        'manila_api_microversion',
+        default='2.69',
+        help='Manila API microversion')
+]
+
+CONF = cfg.CONF
+CONF.register_opts(manila_opts, group='manila')
+
+LOG = logging.getLogger(__name__)
+
+
+class BlazarManilaClient(object):
+    """Client class for Manila service."""
+
+    def __init__(self, **kwargs):
+        client_kwargs = base.client_kwargs(**kwargs)
+        client_kwargs.setdefault('os_manila_api_version',
+                                 CONF.manila.manila_api_microversion)
+        self.manila = manila_client.Client(
+            CONF.manila.manila_api_version, **client_kwargs)
+
+    def __getattr__(self, attr):
+        return getattr(self.manila, attr)

--- a/etc/blazar/blazar-config-generator.conf
+++ b/etc/blazar/blazar-config-generator.conf
@@ -8,5 +8,6 @@ namespace = oslo.log
 namespace = oslo.messaging
 namespace = oslo.middleware
 namespace = oslo.policy
+namespace = oslo.service.periodic_task
 namespace = oslo.service.service
 namespace = keystonemiddleware.auth_token

--- a/lower-constraints.txt
+++ b/lower-constraints.txt
@@ -77,6 +77,7 @@ python-dateutil==2.7.0
 python-editor==1.0.3
 python-ironicclient==2.4.0
 python-keystoneclient==3.8.0
+python-manilaclient==1.29.0
 python-mimeparse==1.6.0
 python-neutronclient==6.0.0
 python-novaclient==9.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ oslo.service>=1.34.0 # Apache-2.0
 oslo.upgradecheck>=0.1.0 # Apache-2.0
 oslo.utils>=3.33.0 # Apache-2.0
 python-ironicclient>=1.11.0 # Apache-2.0
+python-manilaclient>=1.29.0 # Apache-2.0
 python-neutronclient>=6.0.0 # Apache-2.0
 python-novaclient>=9.1.0 # Apache-2.0
 python-zunclient>=3.5.1 # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,9 @@ blazar.resource.plugins =
 blazar.device.driver.plugins =
     k8s.plugin=blazar.plugins.devices.k8s_plugin:K8sPlugin
     zun.plugin=blazar.plugins.devices.zun_plugin:ZunPlugin
+    
+blazar.network.usage.type.plugins =
+    storage.plugin=blazar.plugins.networks.storage_plugin:StoragePlugin
 
 blazar.api.v1.extensions =
     leases=blazar.api.v1.leases.v1_0:get_rest


### PR DESCRIPTION
changes are made to support the shared file system. in order to
provide isolation among shares created by different projects,
accessing shares requires storage vlans. blazar also
manages the access rules of the shares.

- add extra on start steps. blazar checks the usage_type of a
  reserved network segment and performs the plugin extra on
  start steps.
- add a storage plugin. extra on start steps for storage plugin
  create the neutron components that allow instances to access
  the ganesha external network.
- add a periodic task for managing manila share access rules.
  add/remove the subnet cidrs with access level based on the
  active storage vlan reservations of a project.