### PR TITLE
Allow hosts to be restricted to certain projects

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -642,7 +642,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
             filter_array += plugins_utils.convert_requirements(
                 resource_properties)
         for host in db_api.reservable_host_get_all_by_queries(filter_array):
-            if not self.is_project_allowed(project_id, host):
+            if not self.is_project_allowed(project_id, resource_properties):
                 continue
             if not db_api.host_allocation_get_all_by_values(
                     compute_host_id=host['id']):

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -339,6 +339,10 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
             raise manager_ex.HostHavingServers(host=host_ref,
                                                servers=servers)
         host_details = inventory.get_host_details(host_ref)
+        if 'id' in host_details:
+            # Do not use nova's primary key for this host.
+            # Instead, generate a new one.
+            del host_details['id']
         # NOTE(sbauza): Only last duplicate name for same extra capability
         # will be stored
         to_store = set(host_values.keys()) - set(host_details.keys())

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -2333,7 +2333,9 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         result = self.fake_phys_plugin._matching_hosts(
             '[]', '[]', '1-3',
             datetime.datetime(2013, 12, 19, 20, 00),
-            datetime.datetime(2013, 12, 19, 21, 00))
+            datetime.datetime(2013, 12, 19, 21, 00),
+            None
+        )
         self.assertEqual(set(['host2', 'host3']), set(result))
 
     def test_matching_hosts_allocated_hosts(self):
@@ -2362,7 +2364,9 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         result = self.fake_phys_plugin._matching_hosts(
             '[]', '[]', '3-3',
             datetime.datetime(2013, 12, 19, 20, 00),
-            datetime.datetime(2013, 12, 19, 21, 00))
+            datetime.datetime(2013, 12, 19, 21, 00),
+            None
+        )
         self.assertEqual(set(['host1', 'host2', 'host3']), set(result))
 
     def test_matching_hosts_allocated_hosts_with_cleaning_time(self):
@@ -2394,7 +2398,9 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         result = self.fake_phys_plugin._matching_hosts(
             '[]', '[]', '3-3',
             datetime.datetime(2013, 12, 19, 20, 00),
-            datetime.datetime(2013, 12, 19, 21, 00))
+            datetime.datetime(2013, 12, 19, 21, 00),
+            None
+        )
         self.assertEqual(set(['host1', 'host2', 'host3']), set(result))
 
     def test_matching_hosts_not_matching(self):
@@ -2405,7 +2411,9 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         result = self.fake_phys_plugin._matching_hosts(
             '["=", "$memory_mb", "2048"]', '[]', '1-1',
             datetime.datetime(2013, 12, 19, 20, 00),
-            datetime.datetime(2013, 12, 19, 21, 00))
+            datetime.datetime(2013, 12, 19, 21, 00),
+            None
+        )
         self.assertEqual([], result)
 
     def test_check_params_with_valid_before_end(self):


### PR DESCRIPTION
Hosts can now be restricted to projects in a similar fashion to devices (see fed67cfb045692cb6fbc70eb4028ec6cc874cc70). 

Hosts are given a resource property `authorized_projects`, which is a comma-separated list of projects to which the host can be leased.
