### PR TITLE
Allow reallocate to limit scope to a single lease for non-admin users

### DIFF
--- a/blazar/api/v1/oshosts/service.py
+++ b/blazar/api/v1/oshosts/service.py
@@ -94,7 +94,6 @@ class API(object):
         """
         return self.plugin.get_allocations(host_id, query)
 
-    @policy.authorize('oshosts', 'reallocate')
     def reallocate(self, host_id, data):
         """Exchange host from allocations."""
         return self.plugin.reallocate_computehost(host_id, data)

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -123,7 +123,6 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                                           'reservation_id': reservation_id})
         return host_reservation['id']
 
-    @policy.authorize('oshosts', 'put')
     def update_reservation(self, reservation_id, values):
         """Update reservation."""
         reservation = db_api.reservation_get(reservation_id)

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -412,7 +412,6 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                     return False
         return True
 
-    @policy.authorize('oshosts', 'put')
     def update_computehost(self, host_id, values):
         # nothing to update
         if not values:
@@ -595,7 +594,6 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
 
         return host_allocations
 
-    @policy.authorize('oshosts', 'put')
     def update_default_parameters(self, values):
         self.add_default_resource_properties(values)
 

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -529,21 +529,23 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         return {"resource_id": host_id, "reservations": allocs}
 
     def reallocate_computehost(self, host_id, data):
-        lease_id = data.get("lease-id")
+        lease_id = data.get('lease_id')
         if lease_id:
             # If we're only reallocating a host for a single lease,
             # then we allow non-admin users to perform this action,
             # but only on leases they own
             lease = db_api.lease_get(lease_id)
             ctx = context.current()
+            prid = lease['project_id']
             policy.check_enforcement('leases', action='put', ctx=ctx, target={
-                'project': lease.project_id,
+                'project': prid,
                 'user': ctx.user_id,
-                'project_id': lease.project_id,
+                'project_id': prid,
                 'user_id': ctx.user_id,
             })
         else:
             policy.check_enforcement('oshosts', action='reallocate')
+
         allocations = self.get_allocations(host_id, data, detail=True)
 
         for alloc in allocations['reservations']:

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -536,7 +536,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
             lease = db_api.lease_get(lease_id)
             ctx = context.current()
             prid = lease['project_id']
-            policy.check_enforcement('leases', action='put', ctx=ctx, target={
+            policy.check_enforcement('leases', action='reallocate', ctx=ctx, target={
                 'project': prid,
                 'user': ctx.user_id,
                 'project_id': prid,

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -20,7 +20,7 @@ from novaclient import exceptions as nova_exceptions
 from oslo_config import cfg
 from oslo_utils import strutils
 
-from blazar import context
+from blazar import context, policy
 from blazar.db import api as db_api
 from blazar.db import exceptions as db_ex
 from blazar.db import utils as db_utils
@@ -123,6 +123,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                                           'reservation_id': reservation_id})
         return host_reservation['id']
 
+    @policy.authorize('oshosts', 'put')
     def update_reservation(self, reservation_id, values):
         """Update reservation."""
         reservation = db_api.reservation_get(reservation_id)
@@ -411,6 +412,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                     return False
         return True
 
+    @policy.authorize('oshosts', 'put')
     def update_computehost(self, host_id, values):
         # nothing to update
         if not values:
@@ -528,6 +530,8 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         return {"resource_id": host_id, "reservations": allocs}
 
     def reallocate_computehost(self, host_id, data):
+        LOG.debug(data)
+        policy.check_enforcement("oshosts", action="reallocate")
         allocations = self.get_allocations(host_id, data, detail=True)
 
         for alloc in allocations['reservations']:
@@ -591,6 +595,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
 
         return host_allocations
 
+    @policy.authorize('oshosts', 'put')
     def update_default_parameters(self, values):
         self.add_default_resource_properties(values)
 

--- a/blazar/policies/leases.py
+++ b/blazar/policies/leases.py
@@ -55,6 +55,18 @@ leases_policies = [
         ]
     ),
     policy.DocumentedRuleDefault(
+        name=POLICY_ROOT % 'reallocate',
+        check_str=base.RULE_ADMIN_OR_OWNER,
+        description="Policy rule which allows owners to reallocate "
+                    "the host(s) for their lease",
+        operations=[
+            {
+                'path': '/{api_version}/os-hosts/{host_id}/allocation',
+                'method': 'PUT'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
         name=POLICY_ROOT % 'delete',
         check_str=base.RULE_ADMIN_OR_OWNER,
         description='Policy rule for Delete Lease API.',


### PR DESCRIPTION
Non-admin users are now allowed to use the `host-reallocate` command on leases they own. The command will only be allowed if `--lease-id <lease-id>` is supplied, and the lease is one they own.
