### PR TITLE
storage vlan reservation

### DIFF
--- a/blazar/manager/exceptions.py
+++ b/blazar/manager/exceptions.py
@@ -254,6 +254,14 @@ class NetworkNotFound(exceptions.NotFound):
     msg_fmt = _("Network '%(network)s' not found!")
 
 
+class SubnetpoolNotFound(exceptions.NotFound):
+    msg_fmt = _("Subnetpool '%(subnetpool)s' not found!")
+
+
+class RouterNotFound(exceptions.NotFound):
+    msg_fmt = _("Router '%(router)s' not found!")
+
+
 class InvalidNetwork(exceptions.NotAuthorized):
     msg_fmt = _("Invalid values for network %(network)s")
 
@@ -264,6 +272,11 @@ class NotEnoughNetworksAvailable(NotEnoughResourcesAvailable):
 
 class NetworkCreationFailed(exceptions.BlazarException):
     msg_fmt = _("Failed to create network %(name)s for reservation %(id)s. "
+                "%(msg)s")
+
+
+class NetworkExtraOnStartFailed(exceptions.BlazarException):
+    msg_fmt = _("Failed on extra on start steps for reservation %(id)s. "
                 "%(msg)s")
 
 

--- a/blazar/plugins/networks/storage_plugin.py
+++ b/blazar/plugins/networks/storage_plugin.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+#
+# Author: Chameleon Cloud
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from blazar.manager import exceptions as manager_ex
+from blazar.utils.openstack import manila
+from blazar.utils.openstack import neutron
+import collections
+from oslo_config import cfg
+from oslo_log import log as logging
+from oslo_service import periodic_task
+
+opts = [
+    cfg.IntOpt('set_manila_share_access_rules_interval',
+               default=5*60,
+               help='Set access rules for all manila shares every N seconds.'
+                    'If this number is negative the periodic task will be '
+                    'disabled.'),
+    cfg.StrOpt('ceph_nfs_share_type',
+               default='default_share_type',
+               help='The Ceph NFS share type'),
+    cfg.StrOpt('storage_subnetpool',
+               default='filesystem-subnet-pool',
+               help='The storage subnet pool name'),
+    cfg.StrOpt('storage_router',
+               default='filesystem-ganesha-router',
+               help='The storage router name'),
+]
+
+CONF = cfg.CONF
+CONF.register_opts(opts, group="network_storage")
+LOG = logging.getLogger(__name__)
+
+STORAGE_ROUTER_NAME = "storage_router_{network_segment_id}"
+
+
+class StoragePlugin():
+    """Plugin for storage usage type."""
+    usage_type = "storage"
+
+    def __init__(self):
+        super(StoragePlugin, self).__init__()
+        self.neutron_client = neutron.BlazarNeutronClient()
+        self.manila_client = manila.BlazarManilaClient()
+        # get ganesha subnetpool by name
+        ganesha_subnetpool = self.neutron_client.list_subnetpools(
+            name=CONF.network_storage.storage_subnetpool
+        ).get("subnetpools")
+        self.ganesha_subnetpool = next(
+            iter(ganesha_subnetpool), None
+        )
+        if not self.ganesha_subnetpool:
+            raise manager_ex.SubnetpoolNotFound(
+                network=CONF.network_storage.storage_subnetpool
+            )
+        # get ganesha router by name
+        ganesha_router = self.neutron_client.list_routers(
+            name=CONF.network_storage.storage_router
+        ).get("routers")
+        self.ganesha_router = next(
+            iter(ganesha_router), None
+        )
+        if not self.ganesha_router:
+            raise manager_ex.RouterNotFound(
+                network=CONF.network_storage.storage_router
+            )
+        # collect periodic tasks
+        self.periodic_tasks = [self._set_manila_share_access_rules]
+
+    def perform_extra_on_start_steps(self, network_segment, neutron_network):
+        neutron_network = neutron_network["network"]
+        try:
+            # create a subnet with the reserved network and subnetpool
+            subnet_body = {
+                    "subnet": {
+                        "name": f"{neutron_network['name']}-subnet",
+                        "subnetpool_id": self.ganesha_subnetpool["id"],
+                        "network_id": neutron_network["id"],
+                        "ip_version": 4,
+                        "project_id": neutron_network["project_id"],
+                    }
+            }
+            subet = self.neutron_client.create_subnet(body=subnet_body)
+            # share the network with service project
+            rbac_policy_body = {
+                "rbac_policy": {
+                    "object_type": "network",
+                    "action": "access_as_shared",
+                    "target_tenant": CONF.os_admin_project_name,
+                    "object_id": neutron_network["id"],
+                }
+            }
+            self.neutron_client.create_rbac_policy(
+                rbac_policy_body
+            )
+            # add the subnet to ganesha router
+            interface_body = {
+                'subnet_id': subet["subnet"]["id"],
+            }
+            self.neutron_client.add_interface_router(
+                router=self.ganesha_router["id"], body=interface_body
+            )
+        except Exception as e:
+            self.neutron_client.delete_network(neutron_network["id"])
+            raise e
+
+    def _get_ganesha_router_interfaces(self):
+        ports = self.neutron_client.list_ports(
+            device_id=self.ganesha_router["id"]
+        )["ports"]
+        result = collections.defaultdict(list)
+        for p in ports:
+            for fixed_ip in p["fixed_ips"]:
+                subnet = self.neutron_client.show_subnet(
+                    fixed_ip["subnet_id"]
+                )["subnet"]
+                result[subnet["tenant_id"]].append(subnet["cidr"])
+
+        return result
+
+    @periodic_task.periodic_task(
+        spacing=CONF.network_storage.set_manila_share_access_rules_interval,
+        run_immediately=True
+    )
+    def _set_manila_share_access_rules(self, manager_obj, context):
+        # get all available shares
+        shares = self.manila_client.shares.list(
+            search_opts={
+                "all_tenants": 1,
+                "share_type": CONF.network_storage.ceph_nfs_share_type,
+                "status": "available",
+            }
+        )
+
+        ganesha_router_project_cidrs = self._get_ganesha_router_interfaces()
+
+        for share in shares:
+            try:
+                proj = share.project_id
+                access_rules = self.manila_client.shares.access_list(share.id)
+                existing_ip_to_rule_id = {
+                    rule.access_to: rule.id for rule in access_rules
+                    if rule.access_level == "rw"
+                }
+                existing_ips = list(existing_ip_to_rule_id.keys())
+                new_ips = ganesha_router_project_cidrs.get(proj, [])
+                ips_to_add = set(new_ips).difference(existing_ips)
+                ips_to_delete = set(existing_ips).difference(new_ips)
+                for ip in ips_to_add:
+                    self.manila_client.shares.allow(
+                        share.id, "ip", ip, "rw"
+                    )
+                for ip in ips_to_delete:
+                    self.manila_client.shares.deny(
+                        share.id, existing_ip_to_rule_id[ip]
+                    )
+                # all users should have ro access to a public share
+                existing_ro_rule_ids = [
+                    rule.id for rule in access_rules
+                    if rule.access_level == "ro"
+                ]
+                if share.is_public and not existing_ro_rule_ids:
+                    for prefix in self.ganesha_subnetpool["prefixes"]:
+                        self.manila_client.shares.allow(
+                            share.id, "ip", prefix, "ro"
+                        )
+                if not share.is_public and existing_ro_rule_ids:
+                    for rule_id in existing_ro_rule_ids:
+                        self.manila_client.shares.deny(
+                            share.id, rule_id
+                        )
+            except Exception as e:
+                LOG.exception(
+                    f"Failed to manage access rules for share {share.id}"
+                )

--- a/blazar/utils/openstack/manila.py
+++ b/blazar/utils/openstack/manila.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2020 University of Chicago
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from oslo_config import cfg
+
+from blazar.utils.openstack import base
+from oslo_log import log as logging
+from manilaclient import client as manila_client
+
+
+manila_opts = [
+    cfg.StrOpt(
+        'manila_api_version',
+        default='2',
+        help='Manila API version'),
+    cfg.StrOpt(
+        'manila_api_microversion',
+        default='2.69',
+        help='Manila API microversion')
+]
+
+CONF = cfg.CONF
+CONF.register_opts(manila_opts, group='manila')
+
+LOG = logging.getLogger(__name__)
+
+
+class BlazarManilaClient(object):
+    """Client class for Manila service."""
+
+    def __init__(self, **kwargs):
+        client_kwargs = base.client_kwargs(**kwargs)
+        client_kwargs.setdefault('os_manila_api_version',
+                                 CONF.manila.manila_api_microversion)
+        self.manila = manila_client.Client(
+            CONF.manila.manila_api_version, **client_kwargs)
+
+    def __getattr__(self, attr):
+        return getattr(self.manila, attr)

--- a/etc/blazar/blazar-config-generator.conf
+++ b/etc/blazar/blazar-config-generator.conf
@@ -8,5 +8,6 @@ namespace = oslo.log
 namespace = oslo.messaging
 namespace = oslo.middleware
 namespace = oslo.policy
+namespace = oslo.service.periodic_task
 namespace = oslo.service.service
 namespace = keystonemiddleware.auth_token

--- a/lower-constraints.txt
+++ b/lower-constraints.txt
@@ -77,6 +77,7 @@ python-dateutil==2.7.0
 python-editor==1.0.3
 python-ironicclient==2.4.0
 python-keystoneclient==3.8.0
+python-manilaclient==1.29.0
 python-mimeparse==1.6.0
 python-neutronclient==6.0.0
 python-novaclient==9.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ oslo.service>=1.34.0 # Apache-2.0
 oslo.upgradecheck>=0.1.0 # Apache-2.0
 oslo.utils>=3.33.0 # Apache-2.0
 python-ironicclient>=1.11.0 # Apache-2.0
+python-manilaclient>=1.29.0 # Apache-2.0
 python-neutronclient>=6.0.0 # Apache-2.0
 python-novaclient>=9.1.0 # Apache-2.0
 python-zunclient>=3.5.1 # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,9 @@ blazar.resource.plugins =
 blazar.device.driver.plugins =
     k8s.plugin=blazar.plugins.devices.k8s_plugin:K8sPlugin
     zun.plugin=blazar.plugins.devices.zun_plugin:ZunPlugin
+    
+blazar.network.usage.type.plugins =
+    storage.plugin=blazar.plugins.networks.storage_plugin:StoragePlugin
 
 blazar.api.v1.extensions =
     leases=blazar.api.v1.leases.v1_0:get_rest


### PR DESCRIPTION
changes are made to support the shared file system. in order to
provide isolation among shares created by different projects,
accessing shares requires storage vlans. blazar also
manages the access rules of the shares.

- add extra on start steps. blazar checks the usage_type of a
  reserved network segment and performs the plugin extra on
  start steps.
- add a storage plugin. extra on start steps for storage plugin
  create the neutron components that allow instances to access
  the ganesha external network.
- add a periodic task for managing manila share access rules.
  add/remove the subnet cidrs with access level based on the
  active storage vlan reservations of a project.