### PR TITLE
update soft delete for device extra capabilities

### DIFF
--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -1652,7 +1652,7 @@ def device_destroy(device_id):
         device.soft_delete(session=session)
 
         # Also delete this device's extra capabilities
-        for capability in device_extra_capability_get_all_per_device(device_id):
+        for capability,platform_version in device_extra_capability_get_all_per_device(device_id):
             capability.soft_delete(session=session)
 
 


### PR DESCRIPTION
`device_extra_capabilities_get_all_per_device` seems to return a list of tuples, of the form (`blazar.db.sqlalchemy.models.DeviceExtraCapability`, `platform_version`)

Attempting to access soft_delete() of the `DeviceExtraCapability` on the tuple will fail, with the (unhelpful) message `Could not locate column in row for column 'soft_delete'`

As I wasn't sure if fixing this behavior in `device_extra_capabilities_get_all_per_device` would cause issues with other callers, I've worked around it just in device_delete