### PR TITLE
Reduce severity of some exceptions

### DIFF
--- a/blazar/status.py
+++ b/blazar/status.py
@@ -227,7 +227,7 @@ class LeaseStatus(BaseStatus):
                         [isinstance(e, non_fatal_type)
                          for non_fatal_type in non_fatal_exceptions])
                     if is_non_fatal:
-                        LOG.warn('Non-fatal exception during transition '
+                        LOG.warning('Non-fatal exception during transition '
                                       'of lease %s', lease_id)
                         db_api.lease_update(lease_id,
                                             {'status': original_status})

--- a/blazar/status.py
+++ b/blazar/status.py
@@ -227,12 +227,12 @@ class LeaseStatus(BaseStatus):
                         [isinstance(e, non_fatal_type)
                          for non_fatal_type in non_fatal_exceptions])
                     if is_non_fatal:
-                        LOG.exception('Non-fatal exception during transition '
+                        LOG.info('Non-fatal exception during transition '
                                       'of lease %s', lease_id)
                         db_api.lease_update(lease_id,
                                             {'status': original_status})
                     else:
-                        LOG.exception('Lease %s went into ERROR status. %s',
+                        LOG.warn('Lease %s went into ERROR status. %s',
                                       lease_id, str(e))
                         db_api.lease_update(lease_id,
                                             {'status': cls.ERROR})

--- a/blazar/status.py
+++ b/blazar/status.py
@@ -227,12 +227,12 @@ class LeaseStatus(BaseStatus):
                         [isinstance(e, non_fatal_type)
                          for non_fatal_type in non_fatal_exceptions])
                     if is_non_fatal:
-                        LOG.info('Non-fatal exception during transition '
+                        LOG.warn('Non-fatal exception during transition '
                                       'of lease %s', lease_id)
                         db_api.lease_update(lease_id,
                                             {'status': original_status})
                     else:
-                        LOG.warn('Lease %s went into ERROR status. %s',
+                        LOG.error('Lease %s went into ERROR status. %s',
                                       lease_id, str(e))
                         db_api.lease_update(lease_id,
                                             {'status': cls.ERROR})


### PR DESCRIPTION
Many exceptions shouldn't be ERRORs in the log-file, in particular ones that don't indicate an issue in blazar's operation.

This PR is the start of a general cleanup for log-levels, with the proposed categorization:

INFO: indication of normal operation. Most enforcement exceptions should land here, as it's "normal" for a project to be low on SU, or to a lease to be rejected if too long.

WARNING: something unexpected happened, but blazar continues to operate. Lease on-end events failing could be this level.

ERROR: Something is wrong with Blazar, and an operator needs to fix it. Uncaught exceptions, un-fixable lease issues should be here. E.g. a lease-end event failed, AND retrying timed out, so the lease is stuck in an error state until an operator fixes it.

I've left all LOGs at WARN for now for consistency, but this is the overall idea.