### PR TITLE
Add check for improperly torn-down host aggregates

### DIFF
--- a/blazar/db/api.py
+++ b/blazar/db/api.py
@@ -132,6 +132,11 @@ def reservation_get_all_by_values(**kwargs):
 
 
 @to_dict
+def reservation_get_all_by_ids(ids):
+    return IMPL.reservation_get_all_by_ids(ids)
+
+
+@to_dict
 def reservation_get(reservation_id):
     """Return specific reservation."""
     return IMPL.reservation_get(reservation_id)
@@ -566,6 +571,12 @@ def reservable_network_get_all_by_queries(queries):
 def unreservable_network_get_all_by_queries(queries):
     """Returns unreservable networks filtered by an array of queries."""
     return IMPL.unreservable_network_get_all_by_queries(queries)
+
+
+@to_dict
+def unreservable_fip_get_all_by_queries(queries):
+    """Returns unreservable floating IPs filtered by an array of queries."""
+    return IMPL.unreservable_fip_get_all_by_queries(queries)
 
 
 def network_destroy(network_id):

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -153,6 +153,12 @@ def reservation_get_all_by_lease_id(lease_id):
     return reservations.all()
 
 
+def reservation_get_all_by_ids(ids):
+    reservation_query = model_query(models.Reservation, get_session())
+    filt = models.Reservation.id.in_(ids)
+    return reservation_query.filter(filt).all()
+
+
 def reservation_get_all_by_values(**kwargs):
     """Returns all entries filtered by col=value."""
 
@@ -1157,6 +1163,12 @@ def reservable_fip_get_all_by_queries(queries):
 
     """
     queries.append('reservable == 1')
+    return fip_get_all_by_queries(queries)
+
+
+def unreservable_fip_get_all_by_queries(queries):
+    """Returns unreseravable fips filtered by an array of queries"""
+    queries.append("reservable == 0")
     return fip_get_all_by_queries(queries)
 
 

--- a/blazar/db/sqlalchemy/utils.py
+++ b/blazar/db/sqlalchemy/utils.py
@@ -131,6 +131,22 @@ def get_reservations_by_network_id(network_id, start_date, end_date):
     return query.all()
 
 
+def get_reservations_by_floatingip_id(floatingip_id, start_date, end_date):
+    session = get_session()
+    border0 = sa.and_(models.Lease.start_date < start_date,
+                      models.Lease.end_date < start_date)
+    border1 = sa.and_(models.Lease.start_date > end_date,
+                      models.Lease.end_date > end_date)
+    query = (api.model_query(models.Reservation, session=session)
+             .join(models.Lease)
+             .join(models.FloatingIPAllocation)
+             .filter(models.FloatingIPAllocation.deleted.is_(None))
+             .filter(models.FloatingIPAllocation.floatingip_id == floatingip_id)
+             .filter(~sa.or_(border0, border1)))
+    return query.all()
+
+
+
 def get_reservations_by_device_id(device_id, start_date, end_date):
     session = get_session()
     border0 = start_date <= models.Lease.end_date

--- a/blazar/db/utils.py
+++ b/blazar/db/utils.py
@@ -116,6 +116,11 @@ def get_reservations_by_network_id(network_id, start_date, end_date):
         network_id, start_date, end_date)
 
 
+def get_reservations_by_floatingip_id(floatingip_id, start_date, end_date):
+    return IMPL.get_reservations_by_floatingip_id(
+        floatingip_id, start_date, end_date)
+
+
 def get_reservations_by_device_id(device_id, start_date, end_date):
     return IMPL.get_reservations_by_device_id(device_id, start_date, end_date)
 

--- a/blazar/utils/openstack/neutron.py
+++ b/blazar/utils/openstack/neutron.py
@@ -36,6 +36,12 @@ class BlazarNeutronClient(object):
         return getattr(self.neutron, attr)
 
 
+class NeutronClientWrapper(object):
+    @property
+    def neutron(self):
+        return BlazarNeutronClient()
+
+
 class FloatingIPPool(BlazarNeutronClient):
 
     def __init__(self, network_id, **kwargs):


### PR DESCRIPTION
When a reservation ends, the hosts reserved by it are supposed to be moved from the reservation's aggregate into the freepool aggregate. Sometimes, this doesn't happen correctly, so there is additional code added to the host monitor to clean up these errors periodically.