### PR TITLE
Removing the call to ironic to detach the port

### DIFF
--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -250,19 +250,6 @@ class NetworkPlugin(base.BasePlugin):
                         msg=str(e)
                     )
 
-    def delete_port(self, neutron_client, ironic_client, port):
-        if port['binding:vnic_type'] == 'baremetal':
-            node = port.get('binding:host_id')
-            node_info = ironic_client.node.get(node)
-
-            if node and node_info.instance_uuid:
-                ironic_client.node.vif_detach(node, port['id'])
-            else:
-                raise Exception("Expected to find attribute binding:host_id "
-                                "on port %s" % port['id'])
-
-        neutron_client.delete_port(port['id'])
-
     def delete_subnet(self, neutron_client, subnet_id):
         neutron_client.delete_subnet(subnet_id)
 
@@ -297,7 +284,7 @@ class NetworkPlugin(base.BasePlugin):
             instance_ports = neutron_client.list_ports(
                 device_owner='compute:nova', network_id=network_id)
             for instance_port in instance_ports['ports']:
-                self.delete_port(neutron_client, ironic_client, instance_port)
+                neutron_client.delete_port(instance_port['id'])
 
             subnets = neutron_client.list_subnets(network_id=network_id)
             subnet_ids = [s['id'] for s in subnets['subnets']]


### PR DESCRIPTION
as this port is already detached when the instance is deleted

detaching the port here is causing 409

removing the entire `delete_port()` looks like this is not being used anywhere
Tested in UC dev

when instance from lease 1 is attached to network from lease 2
The intended behaviour when lease 2 is deleted is to delete the network from lease 2 and remove the interface from instance of lease 1