### PR TITLE
Add check for improperly torn-down host aggregates

### DIFF
--- a/blazar/db/api.py
+++ b/blazar/db/api.py
@@ -132,11 +132,6 @@ def reservation_get_all_by_values(**kwargs):
 
 
 @to_dict
-def reservation_get_all_by_ids(ids):
-    return IMPL.reservation_get_all_by_ids(ids)
-
-
-@to_dict
 def reservation_get(reservation_id):
     """Return specific reservation."""
     return IMPL.reservation_get(reservation_id)

--- a/blazar/db/api.py
+++ b/blazar/db/api.py
@@ -132,6 +132,11 @@ def reservation_get_all_by_values(**kwargs):
 
 
 @to_dict
+def reservation_get_all_by_ids(ids):
+    return IMPL.reservation_get_all_by_ids(ids)
+
+
+@to_dict
 def reservation_get(reservation_id):
     """Return specific reservation."""
     return IMPL.reservation_get(reservation_id)

--- a/blazar/db/sqlalchemy/utils.py
+++ b/blazar/db/sqlalchemy/utils.py
@@ -294,9 +294,10 @@ def get_reservation_allocations_by_device_ids(device_ids, start_date, end_date,
     return reservations
 
 
-def get_recent_non_pending_reservation_by_host_id(host_id):
+def get_most_recent_reservation_info_by_host_id(host_id):
     """returns the recent host reservation which not in
-    pending status and start_date of the reservation is less than current date
+    pending or active status and start_date of the reservation
+    is less than current date
 
     Args:
         host_id (): Host id - primary key of ComputeHost table
@@ -316,7 +317,9 @@ def get_recent_non_pending_reservation_by_host_id(host_id):
         .join(models.Lease)
         .filter(models.ComputeHost.id == host_id)
         .filter(models.Lease.start_date < curr_date)
-        .filter(models.Reservation.status != status.reservation.PENDING)
+        .filter(models.Reservation.status.not_in(
+            [status.reservation.PENDING, status.reservation.ACTIVE]
+        ))
         .group_by(
             models.ComputeHost.id,
             models.ComputeHost.hypervisor_hostname,

--- a/blazar/db/sqlalchemy/utils.py
+++ b/blazar/db/sqlalchemy/utils.py
@@ -307,21 +307,13 @@ def get_recent_non_pending_reservation_by_host_id(host_id):
         session.query(
             models.ComputeHost.id.label('host_id'),
             models.ComputeHost.hypervisor_hostname,
-            models.Reservation.status,
+            models.Reservation.status.label('reservation_status'),
             models.Lease.start_date,
             models.Lease.end_date,
             models.ComputeHostReservation.aggregate_id,
-            models.Reservation.id.label('reservation_id'),
+            models.ComputeHostReservation.reservation_id,
         )
-        .join(models.ComputeHostAllocation)
-        .join(
-            models.Reservation,
-            models.ComputeHostAllocation.reservation_id == models.Reservation.id
-        )
-        .join(
-            models.Lease,
-            models.Reservation.lease_id == models.Lease.id
-        )
+        .join(models.Lease)
         .filter(models.ComputeHost.id == host_id)
         .filter(models.Lease.start_date < curr_date)
         .filter(models.Reservation.status != status.reservation.PENDING)
@@ -332,7 +324,7 @@ def get_recent_non_pending_reservation_by_host_id(host_id):
             models.Lease.start_date,
             models.Lease.end_date,
             models.ComputeHostReservation.aggregate_id,
-             models.Reservation.id,
+            models.ComputeHostReservation.reservation_id,
         )
         .order_by(models.Lease.start_date.desc())
     )

--- a/blazar/db/sqlalchemy/utils.py
+++ b/blazar/db/sqlalchemy/utils.py
@@ -311,6 +311,7 @@ def get_recent_non_pending_reservation_by_host_id(host_id):
             models.Lease.start_date,
             models.Lease.end_date,
             models.ComputeHostReservation.aggregate_id,
+            models.Reservation.id.label('reservation_id'),
         )
         .join(models.ComputeHostAllocation)
         .join(
@@ -331,6 +332,7 @@ def get_recent_non_pending_reservation_by_host_id(host_id):
             models.Lease.start_date,
             models.Lease.end_date,
             models.ComputeHostReservation.aggregate_id,
+             models.Reservation.id,
         )
         .order_by(models.Lease.start_date.desc())
     )

--- a/blazar/db/sqlalchemy/utils.py
+++ b/blazar/db/sqlalchemy/utils.py
@@ -15,7 +15,7 @@
 # under the License.
 
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from blazar.db.sqlalchemy import api
 from blazar.db.sqlalchemy import facade_wrapper
 from blazar.db.sqlalchemy import models
@@ -302,7 +302,7 @@ def get_recent_non_pending_reservation_by_host_id(host_id):
         host_id (): Host id - primary key of ComputeHost table
     """
     session = get_session()
-    curr_date = datetime.now()
+    curr_date = datetime.now() + timedelta(seconds=300)
     query = (
         session.query(
             models.ComputeHost.id.label('host_id'),

--- a/blazar/db/utils.py
+++ b/blazar/db/utils.py
@@ -152,8 +152,8 @@ def get_reservation_allocations_by_device_ids(device_ids, start_date, end_date,
         device_ids, start_date, end_date, lease_id, reservation_id)
 
 
-def get_recent_non_pending_reservation_by_host_id(host_id):
-    return IMPL.get_recent_non_pending_reservation_by_host_id(host_id)
+def get_most_recent_reservation_info_by_host_id(host_id):
+    return IMPL.get_most_recent_reservation_info_by_host_id(host_id)
 
 
 def get_plugin_reservation(resource_type, resource_id):

--- a/blazar/db/utils.py
+++ b/blazar/db/utils.py
@@ -152,6 +152,10 @@ def get_reservation_allocations_by_device_ids(device_ids, start_date, end_date,
         device_ids, start_date, end_date, lease_id, reservation_id)
 
 
+def get_recent_non_pending_reservation_by_host_id(host_id):
+    return IMPL.get_recent_non_pending_reservation_by_host_id(host_id)
+
+
 def get_plugin_reservation(resource_type, resource_id):
     return IMPL.get_plugin_reservation(resource_type, resource_id)
 

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -984,23 +984,23 @@ class PhysicalHostMonitorPlugin(monitor.GeneralMonitorPlugin,
                 raise ValueError("Aggregate list does not contain a freepool!")
             for host in all_hosts:
                 # get the most recent reservation for the host_id and check if we need to move to freepool
-                reservation = db_utils.get_recent_non_pending_reservation_by_host_id(host.id)
-                if reservation and reservation.status == status.reservation.ACTIVE:
-                    LOG.info(f"{host.hypervisor_hostname} is in a active reservation"
-                             f"{reservation.reservation_id}")
+                reservation = db_utils.get_recent_non_pending_reservation_by_host_id(host['id'])
+                if reservation and reservation["reservation_status"] == status.reservation.ACTIVE:
+                    LOG.info(f"{host['hypervisor_hostname']} is in a active reservation"
+                             f"{reservation['reservation_id']}")
                     continue
                 # host not in 'active' or 'pending' reservation should be in freepool
-                host_uuid = host.hypervisor_hostname
-                curr_agg = host_to_agg_map.get(host.hypervisor_hostname)
+                host_uuid = host['hypervisor_hostname']
+                curr_agg = host_to_agg_map.get(host['hypervisor_hostname'])
                 if curr_agg and (curr_agg.name == freepool.name):
                     # if the host is already in freepool skip it
-                    LOG.info(f"{host.hypervisor_hostname} is already in a freepool - skipping it")
+                    LOG.info(f"{host['hypervisor_hostname']} is already in a freepool - skipping it")
                     continue
                 try:
                     # Remove the host from the reservation's aggregate
                     if curr_agg:
-                        LOG.info(f"Removing host {host.hypervisor_name} from aggregate"
-                                 f"{curr_agg.name} - No hosts in it")
+                        LOG.info(f"Removing host {host['hypervisor_hostname']} from aggregate"
+                                 f" {curr_agg.name} - No hosts in it")
                         curr_agg.remove_host(host_uuid)
                         hosts_in_agg = pool.get_computehosts(curr_agg)
                         if not hosts_in_agg:
@@ -1008,7 +1008,7 @@ class PhysicalHostMonitorPlugin(monitor.GeneralMonitorPlugin,
                             curr_agg.delete()
                     # if the host is not in any aggregate and in non-active reservation
                     # it should be moved to freepool
-                    LOG.info(f"Adding host {host.hypervisor_name} to freepool")
+                    LOG.info(f"Adding host {host['hypervisor_hostname']} to freepool")
                     freepool.add_host(host_uuid)
                 except Exception as e:
                     LOG.exception(f"Failed to recover host {host}", exc_info=e)

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -974,34 +974,41 @@ class PhysicalHostMonitorPlugin(monitor.GeneralMonitorPlugin,
                                         if host['id'] in active_hv_ids])
 
             aggregates = self.nova.aggregates.list()
+            # create a map to get the current aggregate of a host in nova
+            host_to_agg_map = {host: agg for agg in aggregates for host in agg.hosts}
             # get all physical hosts
             all_hosts = db_api.host_list()
             pool = nova.ReservationPool()
             freepool = pool.get_aggregate_from_name_or_id(pool.freepool_name)
             if not freepool:
                 raise ValueError("Aggregate list does not contain a freepool!")
-            # create a map to get the current aggregate of a host in nova
-            host_to_agg_map = {host: agg for agg in aggregates for host in agg.hosts}
             for host in all_hosts:
                 # get the most recent reservation for the host_id and check if we need to move to freepool
                 reservation = db_utils.get_recent_non_pending_reservation_by_host_id(host.id)
-                # an aggregate not in 'active' or 'pending' reservation should be in freepool
                 if reservation and reservation.status == status.reservation.ACTIVE:
+                    LOG.info(f"{host.hypervisor_hostname} is in a active reservation"
+                             f"{reservation.reservation_id}")
                     continue
+                # host not in 'active' or 'pending' reservation should be in freepool
                 host_uuid = host.hypervisor_hostname
                 curr_agg = host_to_agg_map.get(host.hypervisor_hostname)
                 if curr_agg and (curr_agg.name == freepool.name):
                     # if the host is already in freepool skip it
+                    LOG.info(f"{host.hypervisor_hostname} is already in a freepool - skipping it")
                     continue
                 try:
                     # Remove the host from the reservation's aggregate
                     if curr_agg:
+                        LOG.info(f"Removing host {host.hypervisor_name} from aggregate"
+                                 f"{curr_agg.name} - No hosts in it")
                         curr_agg.remove_host(host_uuid)
                         hosts_in_agg = pool.get_computehosts(curr_agg)
                         if not hosts_in_agg:
+                            LOG.info(f"Removing aggregate {curr_agg.name} - No hosts in it")
                             curr_agg.delete()
                     # if the host is not in any aggregate and in non-active reservation
                     # it should be moved to freepool
+                    LOG.info(f"Adding host {host.hypervisor_name} to freepool")
                     freepool.add_host(host_uuid)
                 except Exception as e:
                     LOG.exception(f"Failed to recover host {host}", exc_info=e)

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -984,7 +984,7 @@ class PhysicalHostMonitorPlugin(monitor.GeneralMonitorPlugin,
                 raise ValueError("Aggregate list does not contain a freepool!")
             for host in all_hosts:
                 # get the most recent reservation for the host_id and check if we need to move to freepool
-                reservation = db_utils.get_recent_non_pending_reservation_by_host_id(host['id'])
+                reservation = db_utils.get_most_recent_reservation_info_by_host_id(host['id'])
                 if reservation and reservation["reservation_status"] == status.reservation.ACTIVE:
                     LOG.info(f"{host['hypervisor_hostname']} is in a active reservation"
                              f"{reservation['reservation_id']}")

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -2774,33 +2774,60 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
         self.assertEqual(reservation_flags, result)
 
     def test_poll_resource_failures_aggregate_cleanup(self):
-        hosts = []
-        host_get_all = self.patch(db_api,
-                                  'host_get_all_by_filters')
-        host_get_all.return_value = hosts
-        reservations_get_all = self.patch(db_api,
-                                  'reservation_get_all_by_ids')
-        reservations = [{
-            'id': "aggregate-1",
-            'status': status.reservation.ERROR
-        },{
-            'id': "aggregate-2",
-            'status': status.reservation.ACTIVE
-        }]
-        reservations_get_all.return_value = reservations
-        host1 = mock.MagicMock(id=1, hosts=["host-1"])
-        host1.name = "aggregate-1"
-        host2 = mock.MagicMock(id=1, hosts=["host-2"])
-        host2.name = "aggregate-2"
-        freepool = mock.MagicMock(id=1, hosts=["host-3"])
-        freepool.name = "freepool"
-        aggregates = [host1, host2, freepool]
+        # Create a list of hosts
+        host_in_errored_res = mock.MagicMock(**{
+            'id': 1,
+            'hypervisor_hostname': 'host-1'
+        })
+        host_in_active_res = mock.MagicMock(**{
+            'id': 2,
+            'hypervisor_hostname': 'host-2'
+        })
+        host_in_freepool = mock.MagicMock(**{
+            'id': 3,
+            'hypervisor_hostname': 'host-3'
+        })
+
+        # Set up mock responses for the database and Nova
+        hosts_get_all = self.patch(db_api, 'host_get_all_by_filters')
+        hosts_get_all.return_value = []
+        hosts_list = self.patch(db_api, 'host_list')
+        hosts_list.return_value = [
+            host_in_errored_res,
+            host_in_active_res,
+            host_in_freepool,
+        ]
+        get_reservations = self.patch(db_utils, 'get_recent_non_pending_reservation_by_host_id')
+        get_reservations.side_effect = [
+            mock.MagicMock(**{'id': "aggregate-1", 'status': status.reservation.ERROR}),
+            mock.MagicMock(**{'id': "aggregate-2", 'status': status.reservation.ACTIVE}),
+            # if the host has no reservations, it should be moved to freepool
+            None
+        ]
+
+        # Create mock aggregate objects
+        aggregate1 = mock.MagicMock(id=1, hosts=[host_in_errored_res.hypervisor_hostname])
+        aggregate1.configure_mock(name="aggregate-1")
+        aggregate2 = mock.MagicMock(id=2, hosts=[host_in_active_res.hypervisor_hostname])
+        aggregate2.configure_mock(name="aggregate-2")
+        freepool = mock.MagicMock(id=3, hosts=[])
+        freepool.configure_mock(name="freepool")
+        freepool_get = self.patch(nova.ReservationPool, 'get_aggregate_from_name_or_id')
+        freepool_get.return_value = freepool
+        hosts_in_agg = self.patch(nova.ReservationPool, 'get_computehosts')
+        hosts_in_agg.return_value = None
+
         list_aggregates = self.patch(
             self.host_monitor_plugin.nova.aggregates, 'list'
         )
-        list_aggregates.return_value = aggregates
-        result = self.host_monitor_plugin.poll_resource_failures()
-        self.assertEqual(([], ["host-1"]), result)
-        freepool.add_host.assert_called_once_with('host-1')
-        host1.remove_host.assert_called_with('host-1')
-        host1.delete.assert_called_with()
+        list_aggregates.return_value = [aggregate1, aggregate2, freepool]
+        failed_hosts, recovered_hosts = self.host_monitor_plugin.poll_resource_failures()
+
+        self.assertEqual(failed_hosts, [])
+        self.assertEqual(recovered_hosts, [])
+        freepool.add_host.assert_has_calls([
+            mock.call(host_in_errored_res.hypervisor_hostname),
+            mock.call(host_in_freepool.hypervisor_hostname)
+        ])
+        aggregate1.remove_host.assert_called_with(host_in_errored_res.hypervisor_hostname)
+        aggregate1.delete.assert_called_with()

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -2797,7 +2797,7 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
             host_in_active_res,
             host_in_freepool,
         ]
-        get_reservations = self.patch(db_utils, 'get_recent_non_pending_reservation_by_host_id')
+        get_reservations = self.patch(db_utils, 'get_most_recent_reservation_info_by_host_id')
         get_reservations.side_effect = [
             {'id': "aggregate-1", 'reservation_status': status.reservation.ERROR, 'reservation_id': 1},
             {'id': "aggregate-2", 'reservation_status': status.reservation.ACTIVE, 'reservation_id': 2},


### PR DESCRIPTION
When a reservation ends, the hosts reserved by it are supposed to be moved from the reservation's aggregate into the freepool aggregate.

Sometimes, this doesn't happen correctly, so there is additional code added to the host monitor to clean up these errors periodically.