### PR TITLE
remove the active filter as we need reservation with active status

### DIFF
--- a/blazar/db/sqlalchemy/utils.py
+++ b/blazar/db/sqlalchemy/utils.py
@@ -296,8 +296,7 @@ def get_reservation_allocations_by_device_ids(device_ids, start_date, end_date,
 
 def get_most_recent_reservation_info_by_host_id(host_id):
     """returns the recent host reservation which not in
-    pending or active status and start_date of the reservation
-    is less than current date
+    pending status and start_date of the reservation is less than current date
 
     Args:
         host_id (): Host id - primary key of ComputeHost table
@@ -317,9 +316,7 @@ def get_most_recent_reservation_info_by_host_id(host_id):
         .join(models.Lease)
         .filter(models.ComputeHost.id == host_id)
         .filter(models.Lease.start_date < curr_date)
-        .filter(models.Reservation.status.not_in(
-            [status.reservation.PENDING, status.reservation.ACTIVE]
-        ))
+        .filter(models.Reservation.status != status.reservation.PENDING)
         .group_by(
             models.ComputeHost.id,
             models.ComputeHost.hypervisor_hostname,

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -985,6 +985,11 @@ class PhysicalHostMonitorPlugin(monitor.GeneralMonitorPlugin,
             for host in all_hosts:
                 # get the most recent reservation for the host_id and check if we need to move to freepool
                 reservation = db_utils.get_most_recent_reservation_info_by_host_id(host['id'])
+                # ignore the reservation which is active, as the host must already be in the right pool
+                if reservation and reservation["reservation_status"] == status.reservation.ACTIVE:
+                    LOG.info(f"{host['hypervisor_hostname']} is in a active reservation"
+                             f"{reservation['reservation_id']}")
+                    continue
                 # host not in 'active' or 'pending' reservation should be in freepool
                 host_uuid = host['hypervisor_hostname']
                 curr_agg = host_to_agg_map.get(host['hypervisor_hostname'])

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -985,10 +985,6 @@ class PhysicalHostMonitorPlugin(monitor.GeneralMonitorPlugin,
             for host in all_hosts:
                 # get the most recent reservation for the host_id and check if we need to move to freepool
                 reservation = db_utils.get_most_recent_reservation_info_by_host_id(host['id'])
-                if reservation and reservation["reservation_status"] == status.reservation.ACTIVE:
-                    LOG.info(f"{host['hypervisor_hostname']} is in a active reservation"
-                             f"{reservation['reservation_id']}")
-                    continue
                 # host not in 'active' or 'pending' reservation should be in freepool
                 host_uuid = host['hypervisor_hostname']
                 curr_agg = host_to_agg_map.get(host['hypervisor_hostname'])

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import datetime
 from unittest import mock
 
 import ddt
-from unittest import skip
 from novaclient import client as nova_client
 from novaclient import exceptions as nova_exceptions
 from oslo_config import cfg
@@ -26,7 +24,6 @@ from oslo_config import fixture as conf_fixture
 import testtools
 
 from blazar import context
-from blazar import status
 from blazar.db import api as db_api
 from blazar.db import exceptions as db_exceptions
 from blazar.db import utils as db_utils
@@ -41,6 +38,15 @@ from blazar.utils.openstack import placement
 from blazar.utils import trusts
 
 CONF = cfg.CONF
+
+
+class AggregateFake(object):
+
+    def __init__(self, i, name, hosts):
+        self.id = i
+        self.name = name
+        self.hosts = hosts
+
 
 class PhysicalHostPluginSetupOnlyTestCase(tests.TestCase):
 
@@ -65,14 +71,28 @@ class PhysicalHostPluginSetupOnlyTestCase(tests.TestCase):
         self.db_host_extra_capability_get_all_per_host = (
             self.patch(self.db_api, 'host_extra_capability_get_all_per_host'))
 
-    def test__get_extra_capabilities_with_values(self):
-        ComputeHostExtraCapability = collections.namedtuple(
-            'ComputeHostExtraCapability',
-            ['id', 'capability_id', 'capability_value', 'computehost_id'])
-        self.db_host_extra_capability_get_all_per_host.return_value = [
-            (ComputeHostExtraCapability(1, 'foo', 'bar', 1), 'foo'),
-            (ComputeHostExtraCapability(2, 'buzz', 'word', 1), 'buzz')]
+    def test_configuration(self):
+        self.assertEqual("fake-user", self.fake_phys_plugin.username)
+        self.assertEqual("fake-passwd", self.fake_phys_plugin.password)
+        self.assertEqual("fake-user-domain",
+                         self.fake_phys_plugin.user_domain_name)
+        self.assertEqual("fake-pj-name", self.fake_phys_plugin.project_name)
+        self.assertEqual("fake-pj-domain",
+                         self.fake_phys_plugin.project_domain_name)
 
+    def test__get_extra_capabilities_with_values(self):
+        self.db_host_extra_capability_get_all_per_host.return_value = [
+            {'id': 1,
+             'capability_name': 'foo',
+             'capability_value': 'bar',
+             'other': 'value',
+             'computehost_id': 1
+             },
+            {'id': 2,
+             'capability_name': 'buzz',
+             'capability_value': 'word',
+             'computehost_id': 1
+             }]
         res = self.fake_phys_plugin._get_extra_capabilities(1)
         self.assertEqual({'foo': 'bar', 'buzz': 'word'}, res)
 
@@ -136,9 +156,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         self.db_host_extra_capability_update = self.patch(
             self.db_api, 'host_extra_capability_update')
 
-        self.db_host_extra_capability_destroy = self.patch(
-            self.db_api, 'host_extra_capability_destroy')
-
         self.nova = nova
         self.rp_create = self.patch(self.nova.ReservationPool, 'create')
         self.patch(self.nova.ReservationPool, 'get_aggregate_from_name_or_id')
@@ -180,13 +197,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         self.ServerManager = nova.ServerManager
 
-    def reservation_allocation_dict(self, r_id, l_id, p_id, h_ids):
-        return {
-            'id': r_id, 'status': 'active', 'lease_id': l_id,
-            'start_date': '2015-01-01', 'end_date': '2015-01-02',
-            'lease_name': l_id, 'project_id': p_id,
-            'host_ids': h_ids}
-
     def test_get_host(self):
         host = self.fake_phys_plugin.get_computehost(self.fake_host_id)
         self.db_host_get.assert_called_once_with('1')
@@ -223,13 +233,11 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                      'capability_value': 'bar',
                      }
         self.get_extra_capabilities.return_value = {'foo': 'bar'}
-        self.db_host_create.return_value = fake_host
+        self.db_host_create.return_value = self.fake_host
         host = self.fake_phys_plugin.create_computehost(fake_request)
         self.db_host_create.assert_called_once_with(self.fake_host)
         self.prov_create.assert_called_once_with('hypvsr1')
         self.db_host_extra_capability_create.assert_called_once_with(fake_capa)
-        # the returned host will not have id
-        fake_host.pop('id')
         self.assertEqual(fake_host, host)
 
     def test_create_host_with_capabilities_too_long(self):
@@ -270,14 +278,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         self.prov_create.assert_called_once_with('hypvsr1')
         self.prov_delete.assert_called_once_with('hypvsr1')
 
-    def test_create_duplicate_host(self):
-        def fake_db_host_create(*args, **kwargs):
-            raise db_exceptions.BlazarDBDuplicateEntry
-        self.db_host_create.side_effect = fake_db_host_create
-        self.assertRaises(db_exceptions.BlazarDBDuplicateEntry,
-                          self.fake_phys_plugin.create_computehost,
-                          self.fake_host)
-
     def test_create_host_having_issue_when_storing_extra_capability(self):
         def fake_db_host_extra_capability_create(*args, **kwargs):
             raise db_exceptions.BlazarDBException
@@ -285,7 +285,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         fake_host.update({'foo': 'bar'})
         fake_request = fake_host.copy()
         self.get_extra_capabilities.return_value = {'foo': 'bar'}
-        self.db_host_create.return_value = fake_host
+        self.db_host_create.return_value = self.fake_host
         fake = self.db_host_extra_capability_create
         fake.side_effect = fake_db_host_extra_capability_create
         self.assertRaises(manager_exceptions.CantAddExtraCapability,
@@ -296,10 +296,11 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         host_values = {'foo': 'baz'}
 
         self.db_host_extra_capability_get_all_per_name.return_value = [
-            ({'id': 'extra_id1',
-              'computehost_id': self.fake_host_id,
-              'capability_value': 'bar'},
-             'foo'),
+            {'id': 'extra_id1',
+             'computehost_id': self.fake_host_id,
+             'capability_name': 'foo',
+             'capability_value': 'bar'
+             },
         ]
 
         self.get_reservations_by_host = self.patch(
@@ -309,7 +310,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         self.fake_phys_plugin.update_computehost(self.fake_host_id,
                                                  host_values)
         self.db_host_extra_capability_update.assert_called_once_with(
-            'extra_id1', {'capability_value': 'baz'})
+            'extra_id1', {'capability_name': 'foo', 'capability_value': 'baz'})
 
     def test_update_host_having_issue_when_storing_extra_capability(self):
         def fake_db_host_extra_capability_update(*args, **kwargs):
@@ -319,10 +320,11 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             self.db_utils, 'get_reservations_by_host_id')
         self.get_reservations_by_host.return_value = []
         self.db_host_extra_capability_get_all_per_name.return_value = [
-            ({'id': 'extra_id1',
-              'computehost_id': self.fake_host_id,
-              'capability_value': 'bar'},
-             'foo'),
+            {'id': 'extra_id1',
+             'computehost_id': self.fake_host_id,
+             'capability_name': 'foo',
+             'capability_value': 'bar'
+             },
         ]
         fake = self.db_host_extra_capability_update
         fake.side_effect = fake_db_host_extra_capability_update
@@ -342,33 +344,15 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             'capability_value': 'word'
         })
 
-    def test_update_host_with_removed_capability(self):
-        host_values = {'foo': None}
-
-        self.db_host_extra_capability_get_all_per_name.return_value = [
-            ({'id': 'extra_id1',
-              'computehost_id': self.fake_host_id,
-              'capability_value': 'bar'},
-             'foo'),
-        ]
-
-        self.get_reservations_by_host = self.patch(
-            self.db_utils, 'get_reservations_by_host_id')
-        self.get_reservations_by_host.return_value = []
-
-        self.fake_phys_plugin.update_computehost(self.fake_host_id,
-                                                 host_values)
-        self.db_host_extra_capability_destroy.assert_called_once_with(
-            'extra_id1')
-
     def test_update_host_with_used_capability(self):
         host_values = {'foo': 'buzz'}
 
         self.db_host_extra_capability_get_all_per_name.return_value = [
-            ({'id': 'extra_id1',
-              'computehost_id': self.fake_host_id,
-              'capability_value': 'bar'},
-             'foo'),
+            {'id': 'extra_id1',
+             'computehost_id': self.fake_host_id,
+             'capability_name': 'foo',
+             'capability_value': 'bar'
+             },
         ]
         fake_phys_reservation = {
             'resource_type': plugin.RESOURCE_TYPE,
@@ -453,47 +437,32 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_dict(*r) for r
-            in [
-                ('reservation-1', 'lease-1',
-                 'project-1', ['host-1', 'host-2']),
-                ('reservation-2', 'lease-1',
-                 'project-1', ['host-2', 'host-3']),
-                ('reservation-3', 'lease-2', 'project-2', ['host-1'])]]
-
-        self.db_host_list = self.patch(self.db_api, 'host_list')
-        self.db_host_list.return_value = [
-            {'id': 'host-1'}, {'id': 'host-2'}, {'id': 'host-3'}]
+            ('reservation-1', 'lease-1', 'host-1'),
+            ('reservation-1', 'lease-1', 'host-2'),
+            ('reservation-2', 'lease-1', 'host-2'),
+            ('reservation-2', 'lease-1', 'host-3'),
+            ('reservation-3', 'lease-2', 'host-1'),
+        ]
 
         expected = [
             {
                 'resource_id': 'host-1',
                 'reservations': [
-                    {'id': 'reservation-1',
-                        'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
-                    {'id': 'reservation-3',
-                        'lease_id': 'lease-2', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                    {'id': 'reservation-1', 'lease_id': 'lease-1'},
+                    {'id': 'reservation-3', 'lease_id': 'lease-2'},
                 ]
             },
             {
                 'resource_id': 'host-2',
                 'reservations': [
-                    {'id': 'reservation-1',
-                        'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
-                    {'id': 'reservation-2',
-                        'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                    {'id': 'reservation-1', 'lease_id': 'lease-1'},
+                    {'id': 'reservation-2', 'lease_id': 'lease-1'},
                 ]
             },
             {
                 'resource_id': 'host-3',
                 'reservations': [
-                    {'id': 'reservation-2',
-                        'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                    {'id': 'reservation-2', 'lease_id': 'lease-1'},
                 ]
             }
         ]
@@ -512,43 +481,30 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_dict(*r) for r
-            in [
-                ('reservation-1', 'lease-1',
-                 'project-1', ['host-1', 'host-2']),
-                ('reservation-2', 'lease-1',
-                 'project-1', ['host-2', 'host-3'])]]
-
-        self.db_host_list = self.patch(self.db_api, 'host_list')
-        self.db_host_list.return_value = [
-            {'id': 'host-1'}, {'id': 'host-2'}, {'id': 'host-3'}]
+            ('reservation-1', 'lease-1', 'host-1'),
+            ('reservation-1', 'lease-1', 'host-2'),
+            ('reservation-2', 'lease-1', 'host-2'),
+            ('reservation-2', 'lease-1', 'host-3'),
+        ]
 
         expected = [
             {
                 'resource_id': 'host-1',
                 'reservations': [
-                    {'id': 'reservation-1',
-                        'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                    {'id': 'reservation-1', 'lease_id': 'lease-1'},
                 ]
             },
             {
                 'resource_id': 'host-2',
                 'reservations': [
-                    {'id': 'reservation-1',
-                        'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
-                    {'id': 'reservation-2',
-                        'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                    {'id': 'reservation-1', 'lease_id': 'lease-1'},
+                    {'id': 'reservation-2', 'lease_id': 'lease-1'},
                 ]
             },
             {
                 'resource_id': 'host-3',
                 'reservations': [
-                    {'id': 'reservation-2',
-                        'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                    {'id': 'reservation-2', 'lease_id': 'lease-1'},
                 ]
             }
         ]
@@ -567,29 +523,21 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_dict(*r) for r
-            in [
-                ('reservation-1', 'lease-1',
-                 'project-1', ['host-1', 'host-2'])]]
-
-        self.db_host_list = self.patch(self.db_api, 'host_list')
-        self.db_host_list.return_value = [{'id': 'host-1'}, {'id': 'host-2'}]
+            ('reservation-1', 'lease-1', 'host-1'),
+            ('reservation-1', 'lease-1', 'host-2'),
+        ]
 
         expected = [
             {
                 'resource_id': 'host-1',
                 'reservations': [
-                    {'id': 'reservation-1',
-                        'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                    {'id': 'reservation-1', 'lease_id': 'lease-1'},
                 ]
             },
             {
                 'resource_id': 'host-2',
                 'reservations': [
-                    {'id': 'reservation-1',
-                        'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                    {'id': 'reservation-1', 'lease_id': 'lease-1'},
                 ]
             },
         ]
@@ -609,25 +557,18 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_dict(*r) for r
-            in [
-                ('reservation-1', 'lease-1',
-                 'project-1', ['host-1', 'host-2']),
-                ('reservation-2', 'lease-1',
-                 'project-1', ['host-2', 'host-3']),
-                ('reservation-3', 'lease-2', 'project-2', ['host-1'])]]
-
-        self.db_host_list = self.patch(self.db_api, 'host_list')
-        self.db_host_list.return_value = [
-            {'id': 'host-1'}, {'id': 'host-2'}, {'id': 'host-3'}]
+            ('reservation-1', 'lease-1', 'host-1'),
+            ('reservation-1', 'lease-1', 'host-2'),
+            ('reservation-2', 'lease-1', 'host-2'),
+            ('reservation-2', 'lease-1', 'host-3'),
+            ('reservation-3', 'lease-2', 'host-1'),
+        ]
 
         expected = {
             'resource_id': 'host-1',
             'reservations': [
-                {'id': 'reservation-1', 'lease_id': 'lease-1',
-                    'start_date': '2015-01-01', 'end_date': '2015-01-02'},
-                {'id': 'reservation-3', 'lease_id': 'lease-2',
-                    'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                {'id': 'reservation-1', 'lease_id': 'lease-1'},
+                {'id': 'reservation-3', 'lease_id': 'lease-2'},
             ]
         }
         ret = self.fake_phys_plugin.get_allocations('host-1', {})
@@ -643,19 +584,15 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_dict(
-                'reservation-1', 'lease-1', 'project-1', ['host-1']),
+            ('reservation-1', 'lease-1', 'host-1'),
         ]
-
-        self.db_host_list = self.patch(self.db_api, 'host_list')
-        self.db_host_list.return_value = [{'id': 'host-1'}]
 
         expected = {
             'resource_id': 'host-1',
             'reservations': [
-                {'id': 'reservation-1', 'lease_id': 'lease-1',
-                    'start_date': '2015-01-01', 'end_date': '2015-01-02'}]}
-
+                {'id': 'reservation-1', 'lease_id': 'lease-1'},
+            ]
+        }
         ret = self.fake_phys_plugin.get_allocations('host-1',
                                                     {'lease_id': 'lease-1'})
 
@@ -670,18 +607,15 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_dict(
-                'reservation-1', 'lease-1', 'project-1', ['host-1'])]
-
-        self.db_host_list = self.patch(self.db_api, 'host_list')
-        self.db_host_list.return_value = [{'id': 'host-1'}]
+            ('reservation-1', 'lease-1', 'host-1'),
+        ]
 
         expected = {
             'resource_id': 'host-1',
             'reservations': [
-                {'id': 'reservation-1', 'lease_id': 'lease-1',
-                    'start_date': '2015-01-01', 'end_date': '2015-01-02'}]}
-
+                {'id': 'reservation-1', 'lease_id': 'lease-1'},
+            ]
+        }
         ret = self.fake_phys_plugin.get_allocations(
             'host-1', {'reservation_id': 'reservation-1'})
 
@@ -696,18 +630,12 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_get_reserv_allocs.return_value = [
-            self.reservation_allocation_dict(*r) for r
-            in [
-                ('reservation-1', 'lease-1',
-                 'project-1', ['host-1', 'host-2']),
-                ('reservation-2', 'lease-1',
-                 'project-1', ['host-2', 'host-3']),
-                ('reservation-3', 'lease-2', 'project-2', ['host-1'])]]
-
-        self.db_host_list = self.patch(self.db_api, 'host_list')
-        self.db_host_list.return_value = [
-            {'id': 'host-1'}, {'id': 'host-2'}, {'id': 'host-3'}]
-
+            ('reservation-1', 'lease-1', 'host-1'),
+            ('reservation-1', 'lease-1', 'host-2'),
+            ('reservation-2', 'lease-1', 'host-2'),
+            ('reservation-2', 'lease-1', 'host-3'),
+            ('reservation-3', 'lease-2', 'host-1'),
+        ]
         expected = {'resource_id': 'no-reserved-host', 'reservations': []}
         ret = self.fake_phys_plugin.get_allocations('no-reserved-host', {})
 
@@ -724,7 +652,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             'start_date': now,
             'end_date': now + datetime.timedelta(hours=1),
             'resource_type': plugin.RESOURCE_TYPE,
-            'project_id': 'fake-project'
         }
         host_reservation_create = self.patch(self.db_api,
                                              'host_reservation_create')
@@ -747,7 +674,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             'start_date': datetime.datetime(2013, 12, 19, 20, 00),
             'end_date': datetime.datetime(2013, 12, 19, 21, 00),
             'resource_type': plugin.RESOURCE_TYPE,
-            'project_id': 'fake-project'
         }
         self.rp_create.return_value = mock.MagicMock(id=1)
         host_reservation_create = self.patch(self.db_api,
@@ -767,8 +693,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             'hypervisor_properties': '["=", "$memory_mb", "256"]',
             'count_range': '1-1',
             'status': 'pending',
-            'before_end': 'default',
-            'on_start': 'default'
+            'before_end': 'default'
         }
         host_reservation_create.assert_called_once_with(host_values)
         calls = [
@@ -782,6 +707,25 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                  }),
         ]
         host_allocation_create.assert_has_calls(calls)
+
+    @ddt.data("min", "max", "hypervisor_properties", "resource_properties")
+    def test_create_reservation_with_missing_param(self, missing_param):
+        values = {
+            'lease_id': '018c1b43-e69e-4aef-a543-09681539cf4c',
+            'min': 1,
+            'max': 2,
+            'before_end': 'default',
+            'hypervisor_properties': '["=", "$memory_mb", "256"]',
+            'resource_properties': '',
+            'start_date': datetime.datetime(2017, 3, 1, 20, 00),
+            'end_date': datetime.datetime(2017, 3, 2, 20, 00),
+            'resource_type': plugin.RESOURCE_TYPE}
+        del values[missing_param]
+        self.assertRaises(
+            manager_exceptions.MissingParameter,
+            self.fake_phys_plugin.reserve_resource,
+            '441c1476-9f8f-4700-9f30-cd9b6fef3509',
+            values)
 
     @ddt.data({"params": {'max': 0}},
               {"params": {'max': -1}},
@@ -804,7 +748,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             'resource_type': plugin.RESOURCE_TYPE}
         for key, value in params.items():
             values[key] = value
-        self.patch(db_api, 'host_allocation_get_all_by_values')
         self.assertRaises(
             manager_exceptions.MalformedParameter,
             self.fake_phys_plugin.reserve_resource,
@@ -840,7 +783,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         }
         for key, value in params.items():
             values[key] = value
-        self.patch(db_api, 'host_allocation_get_all_by_values')
         self.assertRaises(
             manager_exceptions.MalformedParameter,
             self.fake_phys_plugin.update_reservation,
@@ -860,7 +802,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         }
         self.patch(self.db_api, 'reservation_get')
         self.patch(self.db_api, 'lease_get')
-        self.patch(db_api, 'host_allocation_get_all_by_values')
         host_reservation_get = self.patch(self.db_api,
                                           'host_reservation_get')
         host_reservation_get.return_value = {
@@ -914,8 +855,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2013, 12, 19, 20, 00),
-            'end_date': datetime.datetime(2013, 12, 19, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2013, 12, 19, 21, 00)
         }
         host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
         host_reservation_get.return_value = {
@@ -957,8 +897,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
     def test_update_reservation_move_failure(self):
         values = {
             'start_date': datetime.datetime(2013, 12, 20, 20, 00),
-            'end_date': datetime.datetime(2013, 12, 20, 21, 30),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2013, 12, 20, 21, 30)
         }
         reservation_get = self.patch(self.db_api, 'reservation_get')
         reservation_get.return_value = {
@@ -969,8 +908,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2013, 12, 19, 20, 00),
-            'end_date': datetime.datetime(2013, 12, 19, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2013, 12, 19, 21, 00)
         }
         host_reservation_get = self.patch(
             self.db_api,
@@ -1024,8 +962,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2013, 12, 19, 20, 00),
-            'end_date': datetime.datetime(2013, 12, 19, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2013, 12, 19, 21, 00)
         }
         host_reservation_get = self.patch(
             self.db_api,
@@ -1080,8 +1017,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2013, 12, 19, 20, 00),
-            'end_date': datetime.datetime(2013, 12, 19, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2013, 12, 19, 21, 00)
         }
         host_reservation_get = self.patch(
             self.db_api,
@@ -1148,15 +1084,14 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2017, 7, 12, 20, 00),
-            'end_date': datetime.datetime(2017, 7, 12, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2017, 7, 12, 21, 00)
         }
         host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
         host_reservation_get.return_value = {
             'id': '91253650-cc34-4c4f-bbe8-c943aa7d0c9b',
             'count_range': '2-3',
             'hypervisor_properties': '["=", "$memory_mb", "16384"]',
-            'resource_properties': '',
+            'resource_properties': ''
         }
         host_allocation_get_all = self.patch(
             self.db_api, 'host_allocation_get_all_by_values')
@@ -1196,8 +1131,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             '',
             '1-1',
             datetime.datetime(2017, 7, 12, 20, 00),
-            datetime.datetime(2017, 7, 12, 21, 00),
-            'fake-project'
+            datetime.datetime(2017, 7, 12, 21, 00)
         )
         host_allocation_destroy.assert_not_called()
         host_allocation_create.assert_called_with(
@@ -1226,8 +1160,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2017, 7, 12, 20, 00),
-            'end_date': datetime.datetime(2017, 7, 12, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2017, 7, 12, 21, 00)
         }
         host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
         host_reservation_get.return_value = {
@@ -1267,8 +1200,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             '',
             '1-1',
             datetime.datetime(2017, 7, 12, 20, 00),
-            datetime.datetime(2017, 7, 12, 21, 00),
-            'fake-project'
+            datetime.datetime(2017, 7, 12, 21, 00)
         )
 
     def test_update_reservation_min_decrease(self):
@@ -1286,8 +1218,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2017, 7, 12, 20, 00),
-            'end_date': datetime.datetime(2017, 7, 12, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2017, 7, 12, 21, 00)
         }
         host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
         host_reservation_get.return_value = {
@@ -1348,8 +1279,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2017, 7, 12, 20, 00),
-            'end_date': datetime.datetime(2017, 7, 12, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2017, 7, 12, 21, 00)
         }
         host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
         host_reservation_get.return_value = {
@@ -1396,8 +1326,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             '',
             '0-1',
             datetime.datetime(2017, 7, 12, 20, 00),
-            datetime.datetime(2017, 7, 12, 21, 00),
-            'fake-project'
+            datetime.datetime(2017, 7, 12, 21, 00)
         )
         host_allocation_destroy.assert_not_called()
         host_allocation_create.assert_called_with(
@@ -1426,8 +1355,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2017, 7, 12, 20, 00),
-            'end_date': datetime.datetime(2017, 7, 12, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2017, 7, 12, 21, 00)
         }
         host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
         host_reservation_get.return_value = {
@@ -1464,10 +1392,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         matching_hosts = self.patch(self.fake_phys_plugin, '_matching_hosts')
         matching_hosts.return_value = ['host3']
         host_get = self.patch(self.db_api, 'host_get')
-        host_get.return_value = {
-            'hypervisor_hostname': 'host3_hostname',
-            'service_name': 'service1',
-        }
+        host_get.return_value = {'service_name': 'host3_hostname'}
         add_computehost = self.patch(
             self.nova.ReservationPool, 'add_computehost')
         host_reservation_update = self.patch(self.db_api,
@@ -1483,8 +1408,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             '',
             '0-1',
             datetime.datetime(2017, 7, 12, 20, 00),
-            datetime.datetime(2017, 7, 12, 21, 00),
-            'fake-project'
+            datetime.datetime(2017, 7, 12, 21, 00)
         )
         host_allocation_destroy.assert_not_called()
         host_allocation_create.assert_called_with(
@@ -1514,8 +1438,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2017, 7, 12, 20, 00),
-            'end_date': datetime.datetime(2017, 7, 12, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2017, 7, 12, 21, 00)
         }
         host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
         host_reservation_get.return_value = {
@@ -1557,8 +1480,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             '',
             '0-1',
             datetime.datetime(2017, 7, 12, 20, 00),
-            datetime.datetime(2017, 7, 12, 21, 00),
-            'fake-project'
+            datetime.datetime(2017, 7, 12, 21, 00)
         )
         host_reservation_update.assert_called_with(
             '91253650-cc34-4c4f-bbe8-c943aa7d0c9b',
@@ -1580,16 +1502,14 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2017, 7, 12, 20, 00),
-            'end_date': datetime.datetime(2017, 7, 12, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2017, 7, 12, 21, 00)
         }
         host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
         host_reservation_get.return_value = {
             'id': '91253650-cc34-4c4f-bbe8-c943aa7d0c9b',
             'count_range': '1-2',
             'hypervisor_properties': '["=", "$memory_mb", "16384"]',
-            'resource_properties': '',
-            'project_id': 'fake-project'
+            'resource_properties': ''
         }
         host_allocation_get_all = self.patch(
             self.db_api, 'host_allocation_get_all_by_values')
@@ -1641,8 +1561,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2017, 7, 12, 20, 00),
-            'end_date': datetime.datetime(2017, 7, 12, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2017, 7, 12, 21, 00)
         }
         host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
         host_reservation_get.return_value = {
@@ -1681,8 +1600,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             '',
             '1-1',
             datetime.datetime(2017, 7, 12, 20, 00),
-            datetime.datetime(2017, 7, 12, 21, 00),
-            'fake-project'
+            datetime.datetime(2017, 7, 12, 21, 00)
         )
         host_allocation_create.assert_called_with(
             {
@@ -1713,8 +1631,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         lease_get = self.patch(self.db_api, 'lease_get')
         lease_get.return_value = {
             'start_date': datetime.datetime(2013, 12, 19, 20, 00),
-            'end_date': datetime.datetime(2013, 12, 19, 21, 00),
-            'project_id': 'fake-project'
+            'end_date': datetime.datetime(2013, 12, 19, 21, 00)
         }
         host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
         host_reservation_get.return_value = {
@@ -1755,7 +1672,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             {'compute_host_id': 'host1'},
         ]
         host_get = self.patch(self.db_api, 'host_get')
-        host_get.return_value = {'hypervisor_hostname': 'host1_hostname'}
+        host_get.return_value = {'service_name': 'host1_hostname'}
         add_computehost = self.patch(
             self.nova.ReservationPool, 'add_computehost')
 
@@ -1767,9 +1684,8 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
         host_reservation_get.return_value = {'before_end': ''}
         reservationpool = self.patch(self.nova, 'ReservationPool')
-        fake_lease = {'project_id': 'fake-project'}
         self.fake_phys_plugin.before_end(
-            '04de74e8-193a-49d2-9ab8-cba7b49e45e8', lease=fake_lease)
+            '04de74e8-193a-49d2-9ab8-cba7b49e45e8')
         reservationpool.assert_not_called()
 
     def test_before_end_with_snapshot(self):
@@ -1784,9 +1700,8 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         list_servers = self.patch(self.ServerManager, 'list')
         list_servers.return_value = ['server1', 'server2']
         create_image = self.patch(self.ServerManager, 'create_image')
-        fake_lease = {'project_id': 'fake-project'}
         self.fake_phys_plugin.before_end(
-            '04de74e8-193a-49d2-9ab8-cba7b49e45e8', lease=fake_lease)
+            '04de74e8-193a-49d2-9ab8-cba7b49e45e8')
         create_image.assert_any_call(server='server1')
         create_image.assert_any_call(server='server2')
 
@@ -1828,7 +1743,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             '04de74e8-193a-49d2-9ab8-cba7b49e45e8', {'status': 'completed'})
         host_allocation_destroy.assert_called_with(
             'bfa9aa0b-8042-43eb-a4e6-4555838bf64f')
-        list_servers.assert_called_with(search_opts={'node': 'host',
+        list_servers.assert_called_with(search_opts={'host': 'host',
                                                      'all_tenants': 1})
         delete_server.assert_any_call(server='server1')
         delete_server.assert_any_call(server='server2')
@@ -1870,7 +1785,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         delete_server.assert_not_called()
         delete_pool.assert_called_with(1)
 
-    @skip # these tests pass when ran individually
     def test_heal_reservations_before_start_and_resources_changed(self):
         failed_host = {'id': '1'}
         dummy_reservation = {
@@ -1889,52 +1803,10 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         get_reservations = self.patch(self.db_utils,
                                       'get_reservations_by_host_ids')
         get_reservations.return_value = [dummy_reservation]
-        reallocate = self.patch(self.fake_phys_plugin.monitor, '_reallocate')
+        reallocate = self.patch(self.fake_phys_plugin, '_reallocate')
         reallocate.return_value = True
-        reservation_get = self.patch(self.db_api, 'reservation_get')
-        reservation_get.return_value = dummy_reservation
 
-        dummy_host_reservation = {
-            'aggregate_id': 1
-        }
-        host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
-        host_reservation_get.return_value = dummy_host_reservation
-
-        host_get = self.patch(
-            self.db_api,
-            'reservable_host_get_all_by_queries')
-        host_get.return_value = [
-            {'id': 'host1'},
-            {'id': 'host2'},
-            {'id': 'host3'},
-        ]
-
-        host_get = self.patch(
-            self.db_api,
-            'host_allocation_get_all_by_values')
-
-        def host_allocation_get_all_by_values(**kwargs):
-            if kwargs['compute_host_id'] == 'host1':
-                return True
-        host_get.side_effect = host_allocation_get_all_by_values
-        host_get = self.patch(
-            self.db_utils,
-            'get_free_periods')
-        host_get.return_value = [
-            (datetime.datetime(2013, 12, 19, 20, 00),
-             datetime.datetime(2013, 12, 19, 21, 00)),
-        ]
-        dummy_lease = {
-            'name': 'lease-name',
-            'start_date': datetime.datetime(2020, 1, 1, 12, 00),
-            'end_date': datetime.datetime(2020, 1, 2, 12, 00),
-            'trust_id': 'trust-1'
-        }
-        lease_get = self.patch(self.db_api, 'lease_get')
-        lease_get.return_value = dummy_lease
-        self.patch(self.db_api, 'host_allocation_update')
-
-        result = self.fake_phys_plugin.monitor.heal_reservations(
+        result = self.fake_phys_plugin.heal_reservations(
             [failed_host],
             datetime.datetime(2020, 1, 1, 12, 00),
             datetime.datetime(2020, 1, 1, 13, 00))
@@ -1942,7 +1814,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             dummy_reservation['computehost_allocations'][0])
         self.assertEqual({}, result)
 
-    @skip
     def test_heal_reservations_before_start_and_missing_resources(self):
         failed_host = {'id': '1'}
         dummy_reservation = {
@@ -1961,52 +1832,10 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         get_reservations = self.patch(self.db_utils,
                                       'get_reservations_by_host_ids')
         get_reservations.return_value = [dummy_reservation]
-        reallocate = self.patch(self.fake_phys_plugin.monitor, '_reallocate')
+        reallocate = self.patch(self.fake_phys_plugin, '_reallocate')
         reallocate.return_value = False
-        reservation_get = self.patch(self.db_api, 'reservation_get')
-        reservation_get.return_value = dummy_reservation
 
-        dummy_host_reservation = {
-            'aggregate_id': 1
-        }
-        host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
-        host_reservation_get.return_value = dummy_host_reservation
-
-        host_get = self.patch(
-            self.db_api,
-            'reservable_host_get_all_by_queries')
-        host_get.return_value = [
-            {'id': 'host1'},
-            {'id': 'host2'},
-            {'id': 'host3'},
-        ]
-
-        host_get = self.patch(
-            self.db_api,
-            'host_allocation_get_all_by_values')
-
-        def host_allocation_get_all_by_values(**kwargs):
-            if kwargs['compute_host_id'] == 'host1':
-                return True
-        host_get.side_effect = host_allocation_get_all_by_values
-        host_get = self.patch(
-            self.db_utils,
-            'get_free_periods')
-        host_get.return_value = [
-            (datetime.datetime(2013, 12, 19, 20, 00),
-             datetime.datetime(2013, 12, 19, 21, 00)),
-        ]
-        dummy_lease = {
-            'name': 'lease-name',
-            'start_date': datetime.datetime(2020, 1, 1, 12, 00),
-            'end_date': datetime.datetime(2020, 1, 2, 12, 00),
-            'trust_id': 'trust-1'
-        }
-        lease_get = self.patch(self.db_api, 'lease_get')
-        lease_get.return_value = dummy_lease
-        self.patch(self.db_api, 'host_allocation_update')
-
-        result = self.fake_phys_plugin.monitor.heal_reservations(
+        result = self.fake_phys_plugin.heal_reservations(
             [failed_host],
             datetime.datetime(2020, 1, 1, 12, 00),
             datetime.datetime(2020, 1, 1, 13, 00))
@@ -2034,62 +1863,18 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         get_reservations = self.patch(self.db_utils,
                                       'get_reservations_by_host_ids')
         get_reservations.return_value = [dummy_reservation]
-
-        reservation_get = self.patch(self.db_api, 'reservation_get')
-        reservation_get.return_value = dummy_reservation
-
-        dummy_host_reservation = {
-            'aggregate_id': 1
-        }
-        host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
-        host_reservation_get.return_value = dummy_host_reservation
-
-        host_get = self.patch(
-            self.db_api,
-            'reservable_host_get_all_by_queries')
-        host_get.return_value = [
-            {'id': 'host1'},
-            {'id': 'host2'},
-            {'id': 'host3'},
-        ]
-
-        host_get = self.patch(
-            self.db_api,
-            'host_allocation_get_all_by_values')
-
-        def host_allocation_get_all_by_values(**kwargs):
-            if kwargs['compute_host_id'] == 'host1':
-                return True
-        host_get.side_effect = host_allocation_get_all_by_values
-        host_get = self.patch(
-            self.db_utils,
-            'get_free_periods')
-        host_get.return_value = [
-            (datetime.datetime(2013, 12, 19, 20, 00),
-             datetime.datetime(2013, 12, 19, 21, 00)),
-        ]
-
-        dummy_lease = {
-            'name': 'lease-name',
-            'start_date': datetime.datetime(2020, 1, 1, 12, 00),
-            'end_date': datetime.datetime(2020, 1, 2, 12, 00),
-            'trust_id': 'trust-1'
-        }
-        lease_get = self.patch(self.db_api, 'lease_get')
-        lease_get.return_value = dummy_lease
-
-        reallocate = self.patch(self.fake_phys_plugin.monitor, '_reallocate')
+        reallocate = self.patch(self.fake_phys_plugin, '_reallocate')
         reallocate.return_value = True
 
-        self.patch(self.db_api, 'host_allocation_update')
-
-        result = self.fake_phys_plugin.monitor.heal_reservations(
+        result = self.fake_phys_plugin.heal_reservations(
             [failed_host],
             datetime.datetime(2020, 1, 1, 12, 00),
             datetime.datetime(2020, 1, 1, 13, 00))
-        # skipped for leases which are active d285bc9
-        reallocate.assert_not_called()
-        self.assertEqual({}, result)
+        reallocate.assert_called_once_with(
+            dummy_reservation['computehost_allocations'][0])
+        self.assertEqual(
+            {dummy_reservation['id']: {'resources_changed': True}},
+            result)
 
     def test_heal_active_reservations_and_missing_resources(self):
         failed_host = {'id': '1'}
@@ -2109,55 +1894,18 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         get_reservations = self.patch(self.db_utils,
                                       'get_reservations_by_host_ids')
         get_reservations.return_value = [dummy_reservation]
-        reservation_get = self.patch(self.db_api, 'reservation_get')
-        reservation_get.return_value = dummy_reservation
-        reallocate = self.patch(self.fake_phys_plugin.monitor, '_reallocate')
+        reallocate = self.patch(self.fake_phys_plugin, '_reallocate')
         reallocate.return_value = False
-        dummy_host_reservation = {
-            'aggregate_id': 1
-        }
-        host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
-        host_reservation_get.return_value = dummy_host_reservation
-        dummy_lease = {
-            'name': 'lease-name',
-            'start_date': datetime.datetime(2020, 1, 1, 12, 00),
-            'end_date': datetime.datetime(2020, 1, 2, 12, 00),
-            'trust_id': 'trust-1'
-        }
-        lease_get = self.patch(self.db_api, 'lease_get')
-        lease_get.return_value = dummy_lease
-        host_get = self.patch(
-            self.db_api,
-            'reservable_host_get_all_by_queries')
-        host_get.return_value = [
-            {'id': 'host1'},
-            {'id': 'host2'},
-            {'id': 'host3'},
-        ]
-        host_get = self.patch(
-            self.db_api,
-            'host_allocation_get_all_by_values')
 
-        def host_allocation_get_all_by_values(**kwargs):
-            if kwargs['compute_host_id'] == 'host1':
-                return True
-        host_get.side_effect = host_allocation_get_all_by_values
-        host_get = self.patch(
-            self.db_utils,
-            'get_free_periods')
-        host_get.return_value = [
-            (datetime.datetime(2013, 12, 19, 20, 00),
-             datetime.datetime(2013, 12, 19, 21, 00)),
-        ]
-        self.patch(self.db_api, 'host_allocation_update')
-
-        result = self.fake_phys_plugin.monitor.heal_reservations(
+        result = self.fake_phys_plugin.heal_reservations(
             [failed_host],
             datetime.datetime(2020, 1, 1, 12, 00),
             datetime.datetime(2020, 1, 1, 13, 00))
-        # skipped for leases which are active d285bc9
-        reallocate.assert_not_called()
-        self.assertEqual({}, result)
+        reallocate.assert_called_once_with(
+            dummy_reservation['computehost_allocations'][0])
+        self.assertEqual(
+            {dummy_reservation['id']: {'missing_resources': True}},
+            result)
 
     def test_reallocate_before_start(self):
         failed_host = {'id': '1'}
@@ -2165,7 +1913,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         dummy_allocation = {
             'id': 'alloc-1',
             'compute_host_id': failed_host['id'],
-            'reservation_id': 'rsrv-1',
+            'reservation_id': 'rsrv-1'
         }
         dummy_reservation = {
             'id': 'rsrv-1',
@@ -2183,8 +1931,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             'name': 'lease-name',
             'start_date': datetime.datetime(2020, 1, 1, 12, 00),
             'end_date': datetime.datetime(2020, 1, 2, 12, 00),
-            'trust_id': 'trust-1',
-            'project_id': 'fake-project'
+            'trust_id': 'trust-1'
         }
         reservation_get = self.patch(self.db_api, 'reservation_get')
         reservation_get.return_value = dummy_reservation
@@ -2206,9 +1953,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         matching_hosts.assert_called_once_with(
             dummy_reservation['hypervisor_properties'],
             dummy_reservation['resource_properties'],
-            '1-1', dummy_lease['start_date'], dummy_lease['end_date'],
-            dummy_lease['project_id']
-        )
+            '1-1', dummy_lease['start_date'], dummy_lease['end_date'])
         alloc_update.assert_called_once_with(
             dummy_allocation['id'],
             {'compute_host_id': new_host['id']})
@@ -2216,9 +1961,9 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
     def test_reallocate_active(self):
         failed_host = {'id': '1',
-                       'hypervisor_hostname': 'compute-1'}
+                       'service_name': 'compute-1'}
         new_host = {'id': '2',
-                    'hypervisor_hostname': 'compute-2'}
+                    'service_name': 'compute-2'}
         dummy_allocation = {
             'id': 'alloc-1',
             'compute_host_id': failed_host['id'],
@@ -2240,8 +1985,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             'name': 'lease-name',
             'start_date': datetime.datetime(2020, 1, 1, 12, 00),
             'end_date': datetime.datetime(2020, 1, 2, 12, 00),
-            'trust_id': 'trust-1',
-            'project_id': 'fake-project'
+            'trust_id': 'trust-1'
         }
         reservation_get = self.patch(self.db_api, 'reservation_get')
         reservation_get.return_value = dummy_reservation
@@ -2260,25 +2004,22 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                                mock.Mock(wraps=datetime.datetime)) as patched:
             patched.utcnow.return_value = datetime.datetime(
                 2020, 1, 1, 13, 00)
-            self.nova_client.client.get.return_value = None, {'servers': []}
             result = self.fake_phys_plugin._reallocate(dummy_allocation)
 
         self.remove_compute_host.assert_called_once_with(
             dummy_host_reservation['aggregate_id'],
-            failed_host['hypervisor_hostname'])
+            failed_host['service_name'])
         matching_hosts.assert_called_once_with(
             dummy_reservation['hypervisor_properties'],
             dummy_reservation['resource_properties'],
             '1-1', datetime.datetime(2020, 1, 1, 13, 00),
-            dummy_lease['end_date'],
-            'fake-project'
-        )
+            dummy_lease['end_date'])
         alloc_update.assert_called_once_with(
             dummy_allocation['id'],
             {'compute_host_id': new_host['id']})
         self.add_compute_host(
             dummy_host_reservation['aggregate_id'],
-            new_host['hypervisor_hostname'])
+            new_host['service_name'])
         self.assertEqual(True, result)
 
     def test_reallocate_missing_resources(self):
@@ -2304,8 +2045,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             'name': 'lease-name',
             'start_date': datetime.datetime(2020, 1, 1, 12, 00),
             'end_date': datetime.datetime(2020, 1, 2, 12, 00),
-            'trust_id': 'trust-1',
-            'project_id': 'fake-project'
+            'trust_id': 'trust-1'
         }
         reservation_get = self.patch(self.db_api, 'reservation_get')
         reservation_get.return_value = dummy_reservation
@@ -2327,9 +2067,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         matching_hosts.assert_called_once_with(
             dummy_reservation['hypervisor_properties'],
             dummy_reservation['resource_properties'],
-            '1-1', dummy_lease['start_date'], dummy_lease['end_date'],
-            dummy_lease['project_id']
-        )
+            '1-1', dummy_lease['start_date'], dummy_lease['end_date'])
         alloc_destroy.assert_called_once_with(dummy_allocation['id'])
         self.assertEqual(False, result)
 
@@ -2359,10 +2097,8 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         result = self.fake_phys_plugin._matching_hosts(
             '[]', '[]', '1-3',
             datetime.datetime(2013, 12, 19, 20, 00),
-            datetime.datetime(2013, 12, 19, 21, 00),
-            None
-        )
-        self.assertEqual(set(['host2', 'host3']), set(result))
+            datetime.datetime(2013, 12, 19, 21, 00))
+        self.assertEqual(['host2', 'host3'], result)
 
     def test_matching_hosts_allocated_hosts(self):
         def host_allocation_get_all_by_values(**kwargs):
@@ -2390,10 +2126,8 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         result = self.fake_phys_plugin._matching_hosts(
             '[]', '[]', '3-3',
             datetime.datetime(2013, 12, 19, 20, 00),
-            datetime.datetime(2013, 12, 19, 21, 00),
-            None
-        )
-        self.assertEqual(set(['host1', 'host2', 'host3']), set(result))
+            datetime.datetime(2013, 12, 19, 21, 00))
+        self.assertEqual(['host1', 'host2', 'host3'], result)
 
     def test_matching_hosts_allocated_hosts_with_cleaning_time(self):
         def host_allocation_get_all_by_values(**kwargs):
@@ -2424,10 +2158,8 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         result = self.fake_phys_plugin._matching_hosts(
             '[]', '[]', '3-3',
             datetime.datetime(2013, 12, 19, 20, 00),
-            datetime.datetime(2013, 12, 19, 21, 00),
-            None
-        )
-        self.assertEqual(set(['host1', 'host2', 'host3']), set(result))
+            datetime.datetime(2013, 12, 19, 21, 00))
+        self.assertEqual(['host1', 'host2', 'host3'], result)
 
     def test_matching_hosts_not_matching(self):
         host_get = self.patch(
@@ -2437,9 +2169,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         result = self.fake_phys_plugin._matching_hosts(
             '["=", "$memory_mb", "2048"]', '[]', '1-1',
             datetime.datetime(2013, 12, 19, 20, 00),
-            datetime.datetime(2013, 12, 19, 21, 00),
-            None
-        )
+            datetime.datetime(2013, 12, 19, 21, 00))
         self.assertEqual([], result)
 
     def test_check_params_with_valid_before_end(self):
@@ -2477,74 +2207,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         self.fake_phys_plugin._check_params(values)
         self.assertEqual(values['before_end'], 'default')
 
-    def test_list_resource_properties(self):
-        self.db_list_resource_properties = self.patch(
-            self.db_api, 'resource_properties_list')
-
-        # Expecting a list of (Reservation, Allocation)
-        self.db_list_resource_properties.return_value = [
-            ('prop1', False, 'aaa'),
-            ('prop1', False, 'bbb'),
-            ('prop2', False, 'aaa'),
-            ('prop2', False, 'aaa'),
-            ('prop3', True, 'aaa')
-        ]
-
-        expected = [
-            {'property': 'prop1'},
-            {'property': 'prop2'}
-        ]
-
-        ret = self.fake_phys_plugin.list_resource_properties(
-            query={'detail': False})
-
-        # Sort returned value to use assertListEqual
-        ret.sort(key=lambda x: x['property'])
-
-        self.assertListEqual(expected, ret)
-        self.db_list_resource_properties.assert_called_once_with(
-            'physical:host')
-
-    def test_list_resource_properties_with_detail(self):
-        self.db_list_resource_properties = self.patch(
-            self.db_api, 'resource_properties_list')
-
-        # Expecting a list of (Reservation, Allocation)
-        self.db_list_resource_properties.return_value = [
-            ('prop1', False, 'aaa'),
-            ('prop1', False, 'bbb'),
-            ('prop2', False, 'ccc'),
-            ('prop3', True, 'aaa')
-        ]
-
-        expected = [
-            {'property': 'prop1', 'private': False, 'values': ['aaa', 'bbb']},
-            {'property': 'prop2', 'private': False, 'values': ['ccc']}
-        ]
-
-        ret = self.fake_phys_plugin.list_resource_properties(
-            query={'detail': True})
-
-        # Sort returned value to use assertListEqual
-        ret.sort(key=lambda x: x['property'])
-
-        self.assertListEqual(expected, ret)
-        self.db_list_resource_properties.assert_called_once_with(
-            'physical:host')
-
-    def test_update_resource_property(self):
-        resource_property_values = {
-            'resource_type': 'physical:host',
-            'private': False}
-
-        db_resource_property_update = self.patch(
-            self.db_api, 'resource_property_update')
-
-        self.fake_phys_plugin.update_resource_property(
-            'foo', resource_property_values)
-        db_resource_property_update.assert_called_once_with(
-            'physical:host', 'foo', resource_property_values)
-
 
 class PhysicalHostMonitorPluginTestCase(tests.TestCase):
 
@@ -2553,8 +2215,26 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
         self.patch(nova_client, 'Client')
         self.host_monitor_plugin = host_plugin.PhysicalHostMonitorPlugin()
 
+    def test_configuration(self):
+        # reset the singleton at first
+        host_plugin.PhysicalHostMonitorPlugin._instance = None
+        self.cfg = self.useFixture(conf_fixture.Config(CONF))
+        self.cfg.config(os_admin_username='fake-user')
+        self.cfg.config(os_admin_password='fake-passwd')
+        self.cfg.config(os_admin_user_domain_name='fake-user-domain')
+        self.cfg.config(os_admin_project_name='fake-pj-name')
+        self.cfg.config(os_admin_project_domain_name='fake-pj-domain')
+        self.host_monitor_plugin = host_plugin.PhysicalHostMonitorPlugin()
+        self.assertEqual('fake-user', self.host_monitor_plugin.username)
+        self.assertEqual("fake-passwd", self.host_monitor_plugin.password)
+        self.assertEqual("fake-user-domain",
+                         self.host_monitor_plugin.user_domain_name)
+        self.assertEqual("fake-pj-name", self.host_monitor_plugin.project_name)
+        self.assertEqual("fake-pj-domain",
+                         self.host_monitor_plugin.project_domain_name)
+
     def test_notification_callback_disabled_true(self):
-        failed_host = {'hypervisor_hostname': 'hypvsr1', 'id': '1'}
+        failed_host = {'hypervisor_hostname': 'hypvsr1'}
         event_type = 'service.update'
         payload = {
             'nova_object.namespace': 'nova',
@@ -2577,13 +2257,15 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
         host_get_all = self.patch(db_api,
                                   'reservable_host_get_all_by_queries')
         host_get_all.return_value = [failed_host]
-        self.patch(db_api, 'host_update')
+        handle_failures = self.patch(self.host_monitor_plugin,
+                                     '_handle_failures')
+        handle_failures.return_value = {'rsrv-1': {'missing_resources': True}}
 
         result = self.host_monitor_plugin.notification_callback(event_type,
                                                                 payload)
         host_get_all.assert_called_once_with(
             ['hypervisor_hostname == ' + payload['nova_object.data']['host']])
-        self.assertEqual({}, result)
+        self.assertEqual({'rsrv-1': {'missing_resources': True}}, result)
 
     def test_notification_callback_no_failure(self):
         event_type = 'service.update'
@@ -2607,12 +2289,15 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
         }
         host_get_all = self.patch(db_api, 'host_get_all_by_queries')
         host_get_all.return_value = []
+        handle_failures = self.patch(self.host_monitor_plugin,
+                                     '_handle_failures')
 
         result = self.host_monitor_plugin.notification_callback(event_type,
                                                                 payload)
         host_get_all.assert_called_once_with(
             ['reservable == 0',
              'hypervisor_hostname == ' + payload['nova_object.data']['host']])
+        handle_failures.assert_not_called()
         self.assertEqual({}, result)
 
     def test_notification_callback_recover(self):
@@ -2638,6 +2323,8 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
         }
         host_get_all = self.patch(db_api, 'host_get_all_by_queries')
         host_get_all.return_value = [recovered_host]
+        handle_failures = self.patch(self.host_monitor_plugin,
+                                     '_handle_failures')
         host_update = self.patch(db_api, 'host_update')
 
         result = self.host_monitor_plugin.notification_callback(event_type,
@@ -2647,6 +2334,7 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
              'hypervisor_hostname == ' + payload['nova_object.data']['host']])
         host_update.assert_called_once_with(recovered_host['id'],
                                             {'reservable': True})
+        handle_failures.assert_not_called()
         self.assertEqual({}, result)
 
     def test_poll_resource_failures_state_down(self):
@@ -2668,7 +2356,7 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
             mock.MagicMock(id=1, state='down', status='enabled'),
             mock.MagicMock(id=2, state='down', status='enabled')]
 
-        result = self.host_monitor_plugin.poll_resource_failures()
+        result = self.host_monitor_plugin._poll_resource_failures()
         self.assertEqual((hosts, []), result)
 
     def test_poll_resource_failures_status_disabled(self):
@@ -2690,7 +2378,7 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
             mock.MagicMock(id=1, state='up', status='disabled'),
             mock.MagicMock(id=2, state='up', status='disabled')]
 
-        result = self.host_monitor_plugin.poll_resource_failures()
+        result = self.host_monitor_plugin._poll_resource_failures()
         self.assertEqual((hosts, []), result)
 
     def test_poll_resource_failures_nothing(self):
@@ -2712,7 +2400,7 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
             mock.MagicMock(id=1, state='up', status='enabled'),
             mock.MagicMock(id=2, state='up', status='enabled')]
 
-        result = self.host_monitor_plugin.poll_resource_failures()
+        result = self.host_monitor_plugin._poll_resource_failures()
         self.assertEqual(([], []), result)
 
     def test_poll_resource_failures_recover(self):
@@ -2734,100 +2422,47 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
             mock.MagicMock(id=1, state='up', status='enabled'),
             mock.MagicMock(id=2, state='up', status='enabled')]
 
-        result = self.host_monitor_plugin.poll_resource_failures()
+        result = self.host_monitor_plugin._poll_resource_failures()
         self.assertEqual(([], hosts), result)
+
+    def test_handle_failures(self):
+        failed_hosts = [
+            {'id': '1',
+             'hypervisor_hostname': 'hypvsr1'}
+        ]
+        host_update = self.patch(db_api, 'host_update')
+        heal = self.patch(self.host_monitor_plugin, 'heal')
+
+        self.host_monitor_plugin._handle_failures(failed_hosts)
+        host_update.assert_called_once_with(failed_hosts[0]['id'],
+                                            {'reservable': False})
+        heal.assert_called_once()
 
     def test_heal(self):
         failed_hosts = [
             {'id': '1',
              'hypervisor_hostname': 'hypvsr1'}
         ]
-        reservation_flags = {}
+        reservation_flags = {
+            'rsrv-1': {'missing_resources': True}
+        }
         hosts_get = self.patch(db_api, 'unreservable_host_get_all_by_queries')
         hosts_get.return_value = failed_hosts
         get_healing_interval = self.patch(self.host_monitor_plugin,
                                           'get_healing_interval')
         get_healing_interval.return_value = 60
+        healing_handler = mock.Mock()
+        healing_handler.return_value = reservation_flags
+        self.host_monitor_plugin.healing_handlers = [healing_handler]
         start_date = datetime.datetime(2020, 1, 1, 12, 00)
-
-        dummy_reservation = {
-            'id': 'rsrv-1',
-            'resource_type': plugin.RESOURCE_TYPE,
-            'lease_id': 'lease-1',
-            'status': 'pending',
-            'hypervisor_properties': [],
-            'resource_properties': [],
-            'resource_id': 'resource-1',
-            'computehost_allocations': [{
-                'id': 'alloc-1', 'compute_host_id': failed_hosts[0]['id'],
-                'reservation_id': 'rsrv-1'
-            }]
-        }
-        get_reservations = self.patch(db_utils, 'get_reservations_by_host_ids')
-        get_reservations.return_value = [dummy_reservation]
 
         with mock.patch.object(datetime, 'datetime',
                                mock.Mock(wraps=datetime.datetime)) as patched:
             patched.utcnow.return_value = start_date
             result = self.host_monitor_plugin.heal()
 
-        self.assertEqual(reservation_flags, result)
-
-    def test_poll_resource_failures_aggregate_cleanup(self):
-        # Create a list of hosts
-        host_in_errored_res = {
-            'id': 1,
-            'hypervisor_hostname': 'host-1'
-        }
-        host_in_active_res = {
-            'id': 2,
-            'hypervisor_hostname': 'host-2'
-        }
-        host_in_freepool = {
-            'id': 3,
-            'hypervisor_hostname': 'host-3'
-        }
-
-        # Set up mock responses for the database and Nova
-        hosts_get_all = self.patch(db_api, 'host_get_all_by_filters')
-        hosts_get_all.return_value = []
-        hosts_list = self.patch(db_api, 'host_list')
-        hosts_list.return_value = [
-            host_in_errored_res,
-            host_in_active_res,
-            host_in_freepool,
-        ]
-        get_reservations = self.patch(db_utils, 'get_most_recent_reservation_info_by_host_id')
-        get_reservations.side_effect = [
-            {'id': "aggregate-1", 'reservation_status': status.reservation.ERROR, 'reservation_id': 1},
-            {'id': "aggregate-2", 'reservation_status': status.reservation.ACTIVE, 'reservation_id': 2},
-            # if the host has no reservations, it should be moved to freepool
-            None
-        ]
-
-        # Create mock aggregate objects
-        aggregate1 = mock.MagicMock(id=1, hosts=[host_in_errored_res["hypervisor_hostname"]])
-        aggregate1.configure_mock(name="aggregate-1")
-        aggregate2 = mock.MagicMock(id=2, hosts=[host_in_active_res["hypervisor_hostname"]])
-        aggregate2.configure_mock(name="aggregate-2")
-        freepool = mock.MagicMock(id=3, hosts=[])
-        freepool.configure_mock(name="freepool")
-        freepool_get = self.patch(nova.ReservationPool, 'get_aggregate_from_name_or_id')
-        freepool_get.return_value = freepool
-        hosts_in_agg = self.patch(nova.ReservationPool, 'get_computehosts')
-        hosts_in_agg.return_value = None
-
-        list_aggregates = self.patch(
-            self.host_monitor_plugin.nova.aggregates, 'list'
+        healing_handler.assert_called_once_with(
+            failed_hosts, start_date,
+            start_date + datetime.timedelta(minutes=60)
         )
-        list_aggregates.return_value = [aggregate1, aggregate2, freepool]
-        failed_hosts, recovered_hosts = self.host_monitor_plugin.poll_resource_failures()
-
-        self.assertEqual(failed_hosts, [])
-        self.assertEqual(recovered_hosts, [])
-        freepool.add_host.assert_has_calls([
-            mock.call(host_in_errored_res["hypervisor_hostname"]),
-            mock.call(host_in_freepool["hypervisor_hostname"])
-        ])
-        aggregate1.remove_host.assert_called_with(host_in_errored_res["hypervisor_hostname"])
-        aggregate1.delete.assert_called_with()
+        self.assertEqual(reservation_flags, result)


### PR DESCRIPTION
This is supposed to be included in PR #91  

We would like to know if the host is currently in an active reservations so we can skip it as "it is already in the right freepool" Otherwise it would be in an errored state

