### PR TITLE
Host aggregate cleanup - UTC time fix and  better logging

### DIFF
--- a/blazar/db/sqlalchemy/utils.py
+++ b/blazar/db/sqlalchemy/utils.py
@@ -302,7 +302,7 @@ def get_most_recent_reservation_info_by_host_id(host_id):
         host_id (): Host id - primary key of ComputeHost table
     """
     session = get_session()
-    curr_date = datetime.now() + timedelta(seconds=300)
+    curr_date = datetime.utcnow() + timedelta(seconds=300)
     query = (
         session.query(
             models.ComputeHost.id.label('host_id'),

--- a/blazar/plugins/monitor.py
+++ b/blazar/plugins/monitor.py
@@ -40,6 +40,10 @@ monitor_opts = [
                 help='Enable polling-based resource monitoring. '
                      'If it is enabled, the blazar-manager monitors states '
                      'of resource by polling the service API.'),
+    cfg.BoolOpt('dry_polling_monitor',
+                default=False,
+                help='If it is enabled, resource monitor plugin only warns '
+                     'about a resource failure but not heal/fix it.'),
     cfg.IntOpt('polling_interval',
                default=60,
                min=1,


### PR DESCRIPTION
- Use UTC time as blazar DB uses UTC timestamps
- This caused an issue with the monitor plugin moving to `freepool` from a current active reservation as the `get_most_recent_reservation_info_by_host_id` always picks an old reservation that is in deleted or error state
- Better logging with warning messages and debug messages
- Skip a host cleanup if the blazar picked up aggregate is different from the current aggregate in nova - give a warning