### PR TITLE
Devstack upstream fixes

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -62,21 +62,12 @@ function configure_blazar {
 
     ACTUAL_FILTERS=$(iniget $NOVA_CONF filter_scheduler enabled_filters)
     if [[ -z "$ACTUAL_FILTERS" ]]; then
-        iniadd $NOVA_CONF filter_scheduler enabled_filters "RetryFilter, AvailabilityZoneFilter, RamFilter, ComputeFilter, ComputeCapabilitiesFilter, ImagePropertiesFilter, AggregateInstanceExtraSpecsFilter, AggregateMultiTenancyIsolation, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter, BlazarFilter"
+        iniadd $NOVA_CONF filter_scheduler enabled_filters "AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,SameHostFilter,DifferentHostFilter,BlazarFilter"
     else
-        if [[ $ACTUAL_FILTERS != *AggregateInstanceExtraSpecsFilter* ]];  then
-	    ACTUAL_FILTERS="$ACTUAL_FILTERS,AggregateInstanceExtraSpecsFilter"
-        fi
-        if [[ $ACTUAL_FILTERS != *AggregateMultiTenancyIsolation* ]];  then
-	    ACTUAL_FILTERS="$ACTUAL_FILTERS,AggregateMultiTenancyIsolation"
-        fi
-        if [[ $ACTUAL_FILTERS != *ServerGroupAntiAffinityFilter* ]];  then
-	    ACTUAL_FILTERS="$ACTUAL_FILTERS,ServerGroupAntiAffinityFilter"
-        fi
         if [[ $ACTUAL_FILTERS != *BlazarFilter* ]];  then
-	    ACTUAL_FILTERS="$ACTUAL_FILTERS,BlazarFilter"
+            ACTUAL_FILTERS="$ACTUAL_FILTERS,BlazarFilter"
         fi
-	iniset $NOVA_CONF filter_scheduler enabled_filters $ACTUAL_FILTERS
+        iniset $NOVA_CONF filter_scheduler enabled_filters $ACTUAL_FILTERS
     fi
 
     ACTUAL_AVAILABLE_FILTERS=$(iniget $NOVA_CONF filter_scheduler available_filters)

--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -31,7 +31,7 @@ function configure_blazar {
     touch $BLAZAR_CONF_FILE
 
     iniset $BLAZAR_CONF_FILE DEFAULT os_auth_version v3
-    iniset $BLAZAR_CONF_FILE DEFAULT os_auth_host $(ipv6_unquote $KEYSTONE_AUTH_HOST)
+    iniset $BLAZAR_CONF_FILE DEFAULT os_auth_host $(ipv6_unquote $KEYSTONE_SERVICE_HOST)
     iniset $BLAZAR_CONF_FILE DEFAULT os_auth_port 80
     iniset $BLAZAR_CONF_FILE DEFAULT os_auth_prefix identity
     iniset $BLAZAR_CONF_FILE DEFAULT os_admin_password $SERVICE_PASSWORD
@@ -135,13 +135,16 @@ function create_blazar_accounts {
         "$REGION_NAME" \
         "$blazar_api_url/v1"
 
-    KEYSTONEV3_SERVICE=$(get_or_create_service "keystonev3" \
-        "identityv3" "Keystone Identity Service V3")
-    get_or_create_endpoint $KEYSTONEV3_SERVICE \
+    # Create admin and internal endpoints for keystone. Blazar currently uses
+    # the admin endpoint to interact with keystone, but devstack stopped
+    # creating one in https://review.opendev.org/c/openstack/devstack/+/777345
+    KEYSTONE_SERVICE=$(get_or_create_service "keystone" \
+        "identity" "Keystone Identity Service")
+    get_or_create_endpoint $KEYSTONE_SERVICE \
         "$REGION_NAME" \
-        "$KEYSTONE_SERVICE_PROTOCOL://$KEYSTONE_SERVICE_HOST:$KEYSTONE_SERVICE_PORT/v3" \
-        "$KEYSTONE_AUTH_PROTOCOL://$KEYSTONE_AUTH_HOST:$KEYSTONE_AUTH_PORT/v3" \
-        "$KEYSTONE_SERVICE_PROTOCOL://$KEYSTONE_SERVICE_HOST:$KEYSTONE_SERVICE_PORT/v3"
+        "${KEYSTONE_SERVICE_PROTOCOL}://${KEYSTONE_SERVICE_HOST}/identity" \
+        "${KEYSTONE_SERVICE_PROTOCOL}://${KEYSTONE_SERVICE_HOST}/identity" \
+        "${KEYSTONE_SERVICE_PROTOCOL}://${KEYSTONE_SERVICE_HOST}/identity"
 }
 
 

--- a/doc/source/cli/instance-reservation.rst
+++ b/doc/source/cli/instance-reservation.rst
@@ -11,10 +11,6 @@ The following packages should be installed:
 * blazar-nova
 * python-blazarclient
 
-The following four scheduler filters should be configured in nova.conf:
-
-* BlazarFilter
-
 1. Add hosts into the freepool
 ------------------------------
 

--- a/doc/source/configuration/nova-conf.rst
+++ b/doc/source/configuration/nova-conf.rst
@@ -9,6 +9,6 @@ Please add the following lines to the nova.conf configuration file:
     [filter_scheduler]
     available_filters = nova.scheduler.filters.all_filters
     available_filters = blazarnova.scheduler.filters.blazar_filter.BlazarFilter
-    enabled_filters=RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,AggregateInstanceExtraSpecsFilter,AggregateMultiTenancyIsolation,ServerGroupAntiAffinityFilter,BlazarFilter
+    enabled_filters = AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,SameHostFilter,DifferentHostFilter,BlazarFilter
 
 ..

--- a/doc/source/install/install-without-devstack.rst
+++ b/doc/source/install/install-without-devstack.rst
@@ -90,7 +90,7 @@ Next you need to configure Nova. Please add the following lines to nova.conf fil
     [filter_scheduler]
     available_filters = nova.scheduler.filters.all_filters
     available_filters = blazarnova.scheduler.filters.blazar_filter.BlazarFilter
-    enabled_filters=RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,AggregateInstanceExtraSpecsFilter,AggregateMultiTenancyIsolation,ServerGroupAntiAffinityFilter,BlazarFilter
+    enabled_filters = AvailabilityZoneFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,SameHostFilter,DifferentHostFilter,BlazarFilter
 
 ..
 


### PR DESCRIPTION
Use the upstream fixes for devstack
This was needed to successfully install blazar in devstack (stable/xena) 
- Use KEYSTONE_SERVICE_* variables instead
- The devstack plugin was creating a keystonev3 service with endpoints using port 5000. However, we have been using the main keystone service on port 80
- Synchronise with default enabled_filters: RetryFilter and RamFilter were
removed from Nova