### PR TITLE
Network cleanup

### DIFF
--- a/blazar/db/utils.py
+++ b/blazar/db/utils.py
@@ -165,6 +165,10 @@ def get_most_recent_reservation_info_by_fip_id(host_id):
     return IMPL.get_most_recent_reservation_info_by_fip_id(host_id)
 
 
+def get_most_recent_reservation_info_by_network_id(host_id):
+    return IMPL.get_most_recent_reservation_info_by_network_id(host_id)
+
+
 def get_plugin_reservation(resource_type, resource_id):
     return IMPL.get_plugin_reservation(resource_type, resource_id)
 

--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -859,10 +859,6 @@ class NetworkMonitorPlugin(monitor.GeneralMonitorPlugin, neutron.NeutronClientWr
                 # This means that network works fine as the reservation started fine
                 LOG.debug(f"Network {network_id_from_blazar} - VLAN {segment_id} is in active reservation {network_curr_reservation['id']} - skipping")
                 return
-            LOG.info(
-                f"For network segment {network_id_from_blazar} - VLAN {segment_id} found a reservation "
-                f"{network_curr_reservation['id']} with status {network_curr_reservation['status']}"
-            )
             neutron_client = neutron.BlazarNeutronClient()
             networks = neutron_client.list_networks()['networks']
             network_from_neutron = next((

--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -64,7 +64,7 @@ LOG = logging.getLogger(__name__)
 before_end_options = ['', 'snapshot', 'default', 'email']
 
 QUERY_TYPE_ALLOCATION = 'allocation'
-
+MONITOR_ARGS = {"resource_type": plugin.RESOURCE_TYPE}
 
 def _get_plugins():
     """Return dict of resource-plugin class pairs."""
@@ -107,6 +107,7 @@ class NetworkPlugin(base.BasePlugin):
         super(NetworkPlugin, self).__init__()
         self.plugins = _get_plugins()
         self.periodic_tasks = []
+        self.monitor = NetworkMonitorPlugin(**MONITOR_ARGS)
         for plugin in self.plugins.values():
             if hasattr(plugin, "periodic_tasks"):
                 self.periodic_tasks.extend(plugin.periodic_tasks)
@@ -856,7 +857,7 @@ class NetworkMonitorPlugin(monitor.GeneralMonitorPlugin, neutron.NeutronClientWr
             network_curr_reservation = db_utils.get_most_recent_reservation_info_by_network_id(network_id_from_blazar)
             if network_curr_reservation and network_curr_reservation['status'] == status.reservation.ACTIVE:
                 # This means that network works fine as the reservation started fine
-                LOG.debug(f"Network {network_id_from_blazar} is in active reservation {network_curr_reservation['id']} - skipping")
+                LOG.debug(f"Network {network_id_from_blazar} - VLAN {segment_id} is in active reservation {network_curr_reservation['id']} - skipping")
                 return
             LOG.info(
                 f"For network segment {network_id_from_blazar} - VLAN {segment_id} found a reservation "


### PR DESCRIPTION
NetworkMonitor - Check and Tear down improper blazar networks in neutron

- Iterate through each blazar network to find the networks that are not in 'active' or 'pending' reservation (maybe they are stuck in a lease)
- Tear down such networks in neutron which are not supposed to be in a user's project.
  1. Detach the network's subnets from the router.
  2. Delete the subnet(s)
  3. Delete the network