### PR TITLE
refactor network operations in NetworkMonitorPlugin

### DIFF
--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -820,6 +820,7 @@ def remove_subnet_route_from_router(router_id, subnet_id, dry_run):
     except neutron_ex.NotFound as e:
         raise e
     # Check if any of the routes in router are pointing to subnet
+    routes = router.get('routes', [])
     subnet_routes = [route for route in routes if is_route_pointing_to_subnet(route)]
     for route in subnet_routes:
         LOG.warning(
@@ -830,7 +831,7 @@ def remove_subnet_route_from_router(router_id, subnet_id, dry_run):
         if not dry_run:
             neutron_client.remove_extra_routes_from_router(
                 router_id,
-                {'router': {'routes': route}}
+                {'router': {'routes': [route]}}
             )
 
 

--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -17,6 +17,7 @@
 import datetime
 import concurrent.futures
 from random import shuffle
+import ipaddress
 
 from keystoneauth1 import exceptions as keystone_excptions
 from neutronclient.common import exceptions as neutron_ex
@@ -795,6 +796,44 @@ class NetworkPlugin(base.BasePlugin):
             return db_api.network_list()
 
 
+def remove_subnet_route_from_router(router_id, subnet_id, dry_run):
+    """Removes the route in the router pointing to the subnet
+
+    Args:
+        router_id (str): The router in which routes need to be checked and removed
+        subnet_id (str): the subnet to which routes should be removed
+    """
+    neutron_client = neutron.BlazarNeutronClient()
+    def is_route_pointing_to_subnet(route):
+        if 'gateway' in route:
+            next_hop_ip = ipaddress.ip_address(route['gateway'])
+        elif 'nexthop' in route:
+            next_hop_ip = ipaddress.ip_address(route['nexthop'])
+        subnet_cidr = ipaddress.ip_network(subnet['cidr'])
+        return next_hop_ip in subnet_cidr
+    try:
+        subnet = neutron_client.show_subnet(subnet_id).get('subnet', {})
+    except neutron_ex.NotFound as e:
+        raise e
+    try:
+        router = neutron_client.show_router(router_id).get('router', {})
+    except neutron_ex.NotFound as e:
+        raise e
+    # Check if any of the routes in router are pointing to subnet
+    subnet_routes = [route for route in routes if is_route_pointing_to_subnet(route)]
+    for route in subnet_routes:
+        LOG.warning(
+            f"Removing the route {route} from router {router['id']} "
+            f"as it is pointing to {subnet['id']}"
+        )
+        # remove this subnet route
+        if not dry_run:
+            neutron_client.remove_extra_routes_from_router(
+                router_id,
+                {'router': {'routes': route}}
+            )
+
+
 class NetworkMonitorPlugin(monitor.GeneralMonitorPlugin, neutron.NeutronClientWrapper):
     """
     Monitor plugin for network resources
@@ -875,23 +914,28 @@ class NetworkMonitorPlugin(monitor.GeneralMonitorPlugin, neutron.NeutronClientWr
                 port for port in ports_from_network
                 if port["device_owner"] == "network:router_interface"
             ]
-            if len(router_ports) == 0:
-                LOG.debug(f"No router ports for neutron network {network_id_from_neutron} - VLAN {segment_id}")
             for port in router_ports:
                 for fixed_ip in port["fixed_ips"]:
                     router_id = port["device_id"]
-                    LOG.warning(f"Detaching router {router_id} from Network subnet {fixed_ip['subnet_id']} - VLAN {segment_id}")
+                    subnet_id = fixed_ip["subnet_id"]
+                    try:
+                        remove_subnet_route_from_router(router_id, subnet_id, dry_run)
+                    except Exception as e:
+                        LOG.exception(f"Cannot remove subnet {subnet_id} route in router {router_id} - {e}")
+                    LOG.warning(f"Detaching router {router_id} from Network subnet {subnet_id} - VLAN {segment_id}")
                     if not dry_run:
-                        neutron_client.remove_interface_router(
-                            router_id, {
-                                'subnet_id': fixed_ip["subnet_id"]
-                            }
-                        )
-            for subnet in neutron_client.list_subnets(network_id=network_id_from_neutron)['subnets']:
+                        neutron_client.remove_interface_router(router_id, {'subnet_id': subnet_id})
+            for port in ports_from_network:
+                if not dry_run:
+                    try:
+                        neutron_client.delete_port(port['id'])
+                    except neutron_ex.PortNotFoundClient:
+                        LOG.debug(f"Port {port['id']} not found in neutron")
+            subnets = neutron_client.list_subnets(network_id=network_id_from_neutron)['subnets']
+            for subnet in subnets:
                 LOG.warning(f"Deleting subnet {subnet['id']} - VLAN {segment_id}")
                 if not dry_run:
                     neutron_client.delete_subnet(subnet['id'])
-
             LOG.warning(f"Deleting network {network_id_from_neutron} - VLAN {segment_id}")
             if not dry_run:
                 neutron_client.delete_network(network_id_from_neutron)

--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -814,10 +814,12 @@ def remove_subnet_route_from_router(router_id, subnet_id, dry_run):
     try:
         subnet = neutron_client.show_subnet(subnet_id).get('subnet', {})
     except neutron_ex.NotFound as e:
+        LOG.exception(f"Could not get subnet {subnet_id} - {e}")
         raise e
     try:
         router = neutron_client.show_router(router_id).get('router', {})
     except neutron_ex.NotFound as e:
+        LOG.exception(f"Could not get router {router_id} - {e}")
         raise e
     # Check if any of the routes in router are pointing to subnet
     routes = router.get('routes', [])

--- a/blazar/tests/plugins/networks/test_network_plugin.py
+++ b/blazar/tests/plugins/networks/test_network_plugin.py
@@ -1117,7 +1117,7 @@ class NetworkMonitorPluginTestCase(tests.TestCase):
             }
         ]
         fake_ports = {
-            'ports': [{"fixed_ips": [{"subnet_id": "subnet1"}],
+            'ports': [{"id":"port1", "fixed_ips": [{"subnet_id": "subnet1"}],
             "device_id": "router1",
             "device_owner": "network:router_interface"}]
         }
@@ -1137,6 +1137,12 @@ class NetworkMonitorPluginTestCase(tests.TestCase):
         neutron_list_ports_patch.return_value = fake_ports
         neutron_list_subnets_patch = self.patch(neutron.neutron_client.Client, 'list_subnets')
         neutron_list_subnets_patch.return_value = fake_subnets
+        neutron_list_networks_patch = self.patch(neutron.neutron_client.Client, 'show_subnet')
+        neutron_list_networks_patch.return_value = {'subnet': {'id': 'subnet1', 'cidr': '192.168.1.0/24'}}
+        neutron_list_networks_patch = self.patch(neutron.neutron_client.Client, 'show_router')
+        neutron_list_networks_patch.return_value = {'router': {'id': 'router1', 'routes': [{'gateway': '192.168.1.1'}]}}
+        neutron_remove_interface_patch = self.patch(neutron.neutron_client.Client, 'remove_extra_routes_from_router')
+        neutron_delete_port_patch = self.patch(neutron.neutron_client.Client, 'delete_port')
         neutron_remove_interface_patch = self.patch(neutron.neutron_client.Client, 'remove_interface_router')
         neutron_delete_subnet_patch = self.patch(neutron.neutron_client.Client, 'delete_subnet')
         neutron_delete_network_patch = self.patch(neutron.neutron_client.Client, 'delete_network')
@@ -1158,7 +1164,7 @@ class NetworkMonitorPluginTestCase(tests.TestCase):
             }
         ]
         fake_ports = {
-            'ports': [{"fixed_ips": [{"subnet_id": "subnet1"}],
+            'ports': [{"id":"port1", "fixed_ips": [{"subnet_id": "subnet1"}],
             "device_id": "router1",
             "device_owner": "network:router_interface"}]
         }
@@ -1186,7 +1192,7 @@ class NetworkMonitorPluginTestCase(tests.TestCase):
             }
         ]
         fake_ports = {
-            'ports': [{"fixed_ips": [{"subnet_id": "subnet1"}],
+            'ports': [{"id":"port1", "fixed_ips": [{"subnet_id": "subnet1"}],
             "device_id": "router1",
             "device_owner": "network:router_interface"}]
         }
@@ -1213,7 +1219,7 @@ class NetworkMonitorPluginTestCase(tests.TestCase):
             }
         ]
         fake_ports = {
-            'ports': [{"fixed_ips": [{"subnet_id": "subnet1"}],
+            'ports': [{"id":"port1", "fixed_ips": [{"subnet_id": "subnet1"}],
             "device_id": "router1",
             "device_owner": "network:router_interface"}]
         }
@@ -1242,7 +1248,7 @@ class NetworkMonitorPluginTestCase(tests.TestCase):
             }
         ]
         fake_ports = {
-            'ports': [{"fixed_ips": [{"subnet_id": "subnet1"}],
+            'ports': [{"id":"port1", "fixed_ips": [{"subnet_id": "subnet1"}],
             "device_id": "dhcp1",
             "device_owner": "network:dhcp"}]
         }
@@ -1265,8 +1271,59 @@ class NetworkMonitorPluginTestCase(tests.TestCase):
         neutron_remove_interface_patch = self.patch(neutron.neutron_client.Client, 'remove_interface_router')
         neutron_delete_subnet_patch = self.patch(neutron.neutron_client.Client, 'delete_subnet')
         neutron_delete_network_patch = self.patch(neutron.neutron_client.Client, 'delete_network')
+        neutron_delete_port_patch = self.patch(neutron.neutron_client.Client, 'delete_port')
         result = self.fake_network_monitor_plugin.poll_resource_failures()
         self.assertFalse(neutron_remove_interface_patch.called)
         neutron_delete_subnet_patch.assert_called_once_with("subnet1")
         neutron_delete_network_patch.assert_called_once_with("neutron1")
+        neutron_delete_port_patch.assert_called()
+        self.assertEqual(result, ([], []))
+
+    def test_network_stuck_in_errored_lease_subnet_routes(self):
+        networks_from_blazar = [
+            {
+                'id': 'network1',
+                'segment_id': 'segment1'
+            }
+        ]
+        fake_ports = {
+            "ports": [{"id":"port1", "fixed_ips": [{"subnet_id": "subnet1"}],
+            "device_id": "router1",
+            "device_owner": "network:router_interface"}],
+        }
+        fake_neutron_networks = {
+            'networks': [{"id": "neutron1", "provider:segmentation_id": "segment1"}]
+        }
+        fake_subnets = {'subnets': [{"id": "subnet1"}]}
+        network_list = self.patch(db_api, 'network_list')
+        network_list.return_value = networks_from_blazar
+        get_reservations = self.patch(db_utils, 'get_most_recent_reservation_info_by_network_id')
+        get_reservations.side_effect = [
+            {'id': "1", 'status': status.reservation.ERROR},
+        ]
+        neutron_list_networks_patch = self.patch(neutron.neutron_client.Client, 'list_networks')
+        neutron_list_networks_patch.return_value = fake_neutron_networks
+        neutron_list_ports_patch = self.patch(neutron.neutron_client.Client, 'list_ports')
+        neutron_list_ports_patch.return_value = fake_ports
+        neutron_list_subnets_patch = self.patch(neutron.neutron_client.Client, 'list_subnets')
+        neutron_list_subnets_patch.return_value = fake_subnets
+        neutron_list_networks_patch = self.patch(neutron.neutron_client.Client, 'show_subnet')
+        neutron_list_networks_patch.return_value = {'subnet': {'id': 'subnet1', 'cidr': '192.168.1.0/24'}}
+        neutron_list_networks_patch = self.patch(neutron.neutron_client.Client, 'show_router')
+        neutron_list_networks_patch.return_value = {'router': {'id': 'router1', 'routes': [{'gateway': '192.168.1.1'}]}}
+        neutron_remove_interface_patch = self.patch(neutron.neutron_client.Client, 'remove_extra_routes_from_router')
+        neutron_remove_interface_patch = self.patch(neutron.neutron_client.Client, 'remove_interface_router')
+        neutron_delete_subnet_patch = self.patch(neutron.neutron_client.Client, 'delete_subnet')
+        neutron_delete_network_patch = self.patch(neutron.neutron_client.Client, 'delete_network')
+        neutron_delete_port_patch = self.patch(neutron.neutron_client.Client, 'delete_port')
+        result = self.fake_network_monitor_plugin.poll_resource_failures()
+        neutron_remove_interface_patch.assert_called_once_with(
+            "router1", {
+                'subnet_id': "subnet1"
+            }
+        )
+        neutron_delete_subnet_patch.assert_called_once_with("subnet1")
+        neutron_delete_network_patch.assert_called_once_with("neutron1")
+        neutron_delete_port_patch.assert_called_once_with("port1")
+        neutron_remove_interface_patch.assert_called_once
         self.assertEqual(result, ([], []))


### PR DESCRIPTION
refactors the network operations in the `NetworkMonitorPlugin` class The changes include the introduction of a new method, `remove_subnet_route_from_router`, to handle the removal of subnet routes from a router

without removing the route, the network cleanup is raising the Exception

ConflictException: 409: Client Error for url: <url>, Router interface for subnet on router cannot be deleted, as it is required by one or more routes.

Tested in UC dev by 
- Creating a network lease
- Creating a router
- Attaching the network subnet interface to the router
- Adding a route in the router to the subnet
- Changing the network reservation status to 'error' to trigger the network monitor
- cleaned up the network without the said error

Change-Id: I7e35002ff2e471fe47601e9daea8cf77fe1a01df