### PR TITLE
fix soft delete for blazar network capability

### DIFF
--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -1276,7 +1276,7 @@ def network_destroy(network_id):
         network.soft_delete(session=session)
 
         # Also delete this network's extra capabilities
-        for capability in network_extra_capability_get_all_per_network(network_id):
+        for capability, platform_version in network_extra_capability_get_all_per_network(network_id):
             capability.soft_delete(session=session)
 
 


### PR DESCRIPTION
`network_extra_capability_get_all_per_network` seems to return a list of tuples.

Attempting to access soft_delete() of the NetworkExtraCapability on the tuple will fail, with the (unhelpful) message `Could not locate column in row for column 'soft_delete'`