### PR TITLE
Fix before lease end event error when user email is not set

### DIFF
--- a/blazar/utils/plugins.py
+++ b/blazar/utils/plugins.py
@@ -122,9 +122,13 @@ def send_lease_extension_reminder(lease, region_name):
                   '--lease-id "{lease_id}" '
                   '--end-datetime "{end_datetime}" '
                   '--site "{site}"')
-    if not user.email:
-        LOG.error('Email address not found for user {username}'.format(
-            username=user.name))
+    try:
+        if not user.email:
+            LOG.error('Email address not found for user {username}'.format(
+                username=user.name))
+            return
+    except AttributeError:
+        LOG.error(f"User does not have email attribute - username: {user.name}")
         return
     params = params_tmp.format(recipient=user.email,
                                username=user.name,


### PR DESCRIPTION
If a user does not have an email attribute in the Keystone

But do we need this, when we have keycloak set user email? 

Change-Id: Icc4aaea5ef3d0e95a6ccc885e9345aae21e9cfbd