### PR TITLE
Add validation to ensure unique capabilities when needed and device name

### DIFF
--- a/blazar/db/migration/alembic_migrations/versions/9eec70cbc562_add_is_unique_field_in_extra_.py
+++ b/blazar/db/migration/alembic_migrations/versions/9eec70cbc562_add_is_unique_field_in_extra_.py
@@ -1,0 +1,41 @@
+# Copyright 2024 OpenStack Foundation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Add is_unique field in extra capabilities
+
+Revision ID: 9eec70cbc562
+Revises: d5a379ff6ba3
+Create Date: 2024-03-15 17:36:26.552008
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9eec70cbc562'
+down_revision = 'd5a379ff6ba3'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    op.create_unique_constraint(None, 'devices', ['name'])
+    op.add_column('extra_capabilities', sa.Column('is_unique', sa.Boolean(), server_default=sa.text('false'), nullable=False))
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    op.drop_column('extra_capabilities', 'is_unique')
+    op.drop_constraint(None, 'devices', type_='unique')
+    # ### end Alembic commands ###

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -2045,6 +2045,7 @@ def resource_properties_list(resource_type):
             models.ExtraCapability.capability_name,
             models.ExtraCapability.private,
             resource_model.capability_value,
+            models.ExtraCapability.is_unique,
         ).join(resource_model), resource_model, deleted=False).distinct()
 
         return query.all()

--- a/blazar/db/sqlalchemy/models.py
+++ b/blazar/db/sqlalchemy/models.py
@@ -326,7 +326,7 @@ class ComputeHostExtraCapability(mb.BlazarBase, mb.SoftDeleteMixinWithUuid):
             ).first()
             if existing_capability:
                 raise ValueError(
-                    f"{extra_capability.capability_name} must be unique. "
+                    f"Values for {extra_capability.capability_name} must be unique. "
                     f"Please select unique {extra_capability.capability_name} for "
                     f"{self.computehost_id}"
                 )

--- a/blazar/db/sqlalchemy/models.py
+++ b/blazar/db/sqlalchemy/models.py
@@ -314,23 +314,23 @@ class ComputeHostExtraCapability(mb.BlazarBase, mb.SoftDeleteMixinWithUuid):
     def to_dict(self):
         return super(ComputeHostExtraCapability, self).to_dict()
 
-    @validates('capability_value')
-    def validate_capability_value(self, key, capability_value):
+    @validates('capability_id')
+    def validate_capability_value(self, key, capability_id):
         from blazar.db.sqlalchemy import facade_wrapper
         session = facade_wrapper.get_session()
-        extra_capability = session.query(ExtraCapability).filter_by(id=self.capability_id).first()
+        extra_capability = session.query(ExtraCapability).filter_by(id=capability_id).first()
         if extra_capability and extra_capability.is_unique:
             existing_capability = (
-                session.query(ComputeHostExtraCapability).filter_by(computehost_id=self.computehost_id,
-                                     capability_id=self.capability_id).first()
-            )
+                session.query(ComputeHostExtraCapability).filter_by(
+                       capability_id=extra_capability.id, capability_value=self.capability_value, deleted=None)
+            ).first()
             if existing_capability:
                 raise ValueError(
                     f"{extra_capability.capability_name} must be unique. "
                     f"Please select unique {extra_capability.capability_name} for "
                     f"{self.computehost_id}"
                 )
-        return capability_value
+        return capability_id
 
 
 

--- a/blazar/plugins/base.py
+++ b/blazar/plugins/base.py
@@ -106,15 +106,16 @@ class BasePlugin(object, metaclass=abc.ABCMeta):
         detail = False if not query else query.get('detail', False)
         resource_properties = collections.defaultdict(list)
 
-        for name, private, value in db_api.resource_properties_list(
+        for name, private, value, is_unique in db_api.resource_properties_list(
                 self.resource_type):
 
             if not private:
                 resource_properties[name].append(value)
+                resource_properties[name].append(is_unique)
 
         if detail:
             return [
-                dict(property=k, private=False, values=v)
+                dict(property=k, private=False, values=v[0], is_unique=v[1])
                 for k, v in resource_properties.items()]
         else:
             return [dict(property=k) for k, v in resource_properties.items()]

--- a/blazar/plugins/base.py
+++ b/blazar/plugins/base.py
@@ -105,17 +105,20 @@ class BasePlugin(object, metaclass=abc.ABCMeta):
     def list_resource_properties(self, query):
         detail = False if not query else query.get('detail', False)
         resource_properties = collections.defaultdict(list)
+        is_property_unique = {}
 
         for name, private, value, is_unique in db_api.resource_properties_list(
                 self.resource_type):
-
             if not private:
                 resource_properties[name].append(value)
-                resource_properties[name].append(is_unique)
+                is_property_unique[name] = is_unique
 
         if detail:
             return [
-                dict(property=k, private=False, values=v[0], is_unique=v[1])
+                dict(
+                    property=k, private=False, values=v,
+                    is_unique=is_property_unique[k]
+                )
                 for k, v in resource_properties.items()]
         else:
             return [dict(property=k) for k, v in resource_properties.items()]

--- a/blazar/tests/db/sqlalchemy/test_sqlalchemy_api.py
+++ b/blazar/tests/db/sqlalchemy/test_sqlalchemy_api.py
@@ -551,7 +551,7 @@ class SQLAlchemyDBApiTestCase(tests.DBTestCase):
 
         result = db_api.resource_properties_list('physical:host')
 
-        self.assertListEqual(result, [('vgpu', False, '2')])
+        self.assertListEqual(result, [('vgpu', False, '2', False)])
 
     def test_search_for_hosts_by_composed_queries(self):
         """Create one host and test composed queries."""

--- a/blazar/tests/plugins/networks/test_network_plugin.py
+++ b/blazar/tests/plugins/networks/test_network_plugin.py
@@ -1036,11 +1036,11 @@ class NetworkPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_list_resource_properties.return_value = [
-            ('prop1', False, 'aaa'),
-            ('prop1', False, 'bbb'),
-            ('prop2', False, 'aaa'),
-            ('prop2', False, 'aaa'),
-            ('prop3', True, 'aaa')
+            ('prop1', False, 'aaa', False),
+            ('prop1', False, 'bbb', False),
+            ('prop2', False, 'aaa', False),
+            ('prop2', False, 'aaa', False),
+            ('prop3', True, 'aaa', False)
         ]
 
         expected = [
@@ -1063,15 +1063,15 @@ class NetworkPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_list_resource_properties.return_value = [
-            ('prop1', False, 'aaa'),
-            ('prop1', False, 'bbb'),
-            ('prop2', False, 'ccc'),
-            ('prop3', True, 'aaa')
+            ('prop1', False, 'aaa', False),
+            ('prop1', False, 'bbb', False),
+            ('prop2', False, 'ccc', False),
+            ('prop3', True, 'aaa', False)
         ]
 
         expected = [
-            {'property': 'prop1', 'private': False, 'values': ['aaa', 'bbb']},
-            {'property': 'prop2', 'private': False, 'values': ['ccc']}
+            {'property': 'prop1', 'private': False, 'values': ['aaa', 'bbb'], 'is_unique': False},
+            {'property': 'prop2', 'private': False, 'values': ['ccc'], 'is_unique': False}
         ]
 
         ret = self.fake_network_plugin.list_resource_properties(

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -2549,16 +2549,16 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_list_resource_properties.return_value = [
-            ('prop1', False, 'aaa'),
-            ('prop1', False, 'bbb'),
-            ('prop2', False, 'aaa'),
-            ('prop2', False, 'aaa'),
-            ('prop3', True, 'aaa')
+            ('prop1', False, 'aaa', False),
+            ('prop1', False, 'bbb', False),
+            ('prop2', False, 'aaa', False),
+            ('prop2', False, 'aaa', False),
+            ('prop3', True, 'aaa', False)
         ]
 
         expected = [
-            {'property': 'prop1'},
-            {'property': 'prop2'}
+            {'property': 'prop1',},
+            {'property': 'prop2',}
         ]
 
         ret = self.fake_phys_plugin.list_resource_properties(
@@ -2577,15 +2577,15 @@ class PhysicalHostPluginTestCase(tests.TestCase):
 
         # Expecting a list of (Reservation, Allocation)
         self.db_list_resource_properties.return_value = [
-            ('prop1', False, 'aaa'),
-            ('prop1', False, 'bbb'),
-            ('prop2', False, 'ccc'),
-            ('prop3', True, 'aaa')
+            ('prop1', False, 'aaa', False),
+            ('prop1', False, 'bbb', False),
+            ('prop2', False, 'ccc', False),
+            ('prop3', True, 'aaa', False)
         ]
 
         expected = [
-            {'property': 'prop1', 'private': False, 'values': ['aaa', 'bbb']},
-            {'property': 'prop2', 'private': False, 'values': ['ccc']}
+            {'property': 'prop1', 'private': False, 'values': ['aaa', 'bbb'], 'is_unique': False},
+            {'property': 'prop2', 'private': False, 'values': ['ccc'], 'is_unique': False}
         ]
 
         ret = self.fake_phys_plugin.list_resource_properties(


### PR DESCRIPTION
Added a validation method `validate_capability_value` to the `ComputeHostExtraCapability` model to enforce uniqueness of `ExtraCapability`'s `capability_name` when its `is_unique=True`. This validation ensures that only one capability is allowed for each resource when is_unique is set to True. If a duplicate entry is found, a ValueError is raised with details about the non-unique capability and the affected compute host.

Set Uniqueness for `name` in `Device` model

python-blazarclient PR - https://github.com/ChameleonCloud/python-blazarclient/pull/30

Change-Id: I523a133abe15797cfb5b0b0edc830918dbe26f15