### PR TITLE
Add validation for capability value - updating the value

### DIFF
--- a/blazar/db/sqlalchemy/models.py
+++ b/blazar/db/sqlalchemy/models.py
@@ -314,32 +314,36 @@ class ComputeHostExtraCapability(mb.BlazarBase, mb.SoftDeleteMixinWithUuid):
     def to_dict(self):
         return super(ComputeHostExtraCapability, self).to_dict()
 
-    @validates('capability_id')
-    def validate_capability_id(self, key, capability_id):
-        # this validation occurs only upon creating the capability
-        from blazar.db.sqlalchemy import facade_wrapper
-        session = facade_wrapper.get_session()
-        extra_capability = session.query(ExtraCapability).filter_by(id=capability_id).first()
-        if extra_capability and extra_capability.is_unique:
-            existing_capability = (
-                session.query(ComputeHostExtraCapability).filter_by(
-                       capability_id=extra_capability.id, capability_value=self.capability_value, deleted=None)
-            ).first()
-            if existing_capability:
-                raise ValueError(
-                    f"Values for {extra_capability.capability_name} must be unique. "
-                    f"Please select unique {extra_capability.capability_name} for "
-                    f"{self.computehost_id}"
-                )
-        return capability_id
 
-    @validates('capability_value')
-    def validate_capability_value(self, key, capability_value):
-        # this validation occurs when updating the capability value
-        # this is important when for Eg: node_name capability's value is updated
+    @validates('capability_id', 'capability_value')
+    def validate_capability(self, key, value):
+        """Validates the capability ID and value before assigning
+        them to a ComputeHostExtraCapability instance.
+
+        This validation method is called for two scenarios:
+        1. When a capability ID is first assigned to a compute host.
+            both capability_id and capability_value are validated in this case
+        2. When a capability value is updated for an existing capability ID.
+
+        Args:
+            key (str): The attribute key being validated
+                ('capability_id' or 'capability_value').
+            value (str)
+
+        Raises:
+            ValueError
+
+        Returns:
+            str
+        """
         from blazar.db.sqlalchemy import facade_wrapper
         session = facade_wrapper.get_session()
-        extra_capability = session.query(ExtraCapability).filter_by(id=self.capability_id).first()
+
+        # Determine the capability ID and value to validate based on the key
+        capability_id = value if key == "capability_id" else self.capability_id
+        capability_value = value if key == "capability_value" else self.capability_value
+
+        extra_capability = session.query(ExtraCapability).filter_by(id=capability_id).first()
         if extra_capability and extra_capability.is_unique:
             # exclude the current compute_host
             # we should allow updating the node_name with current name
@@ -357,7 +361,7 @@ class ComputeHostExtraCapability(mb.BlazarBase, mb.SoftDeleteMixinWithUuid):
                     f"Please select unique {extra_capability.capability_name} for "
                     f"{self.computehost_id}"
                 )
-        return capability_value
+        return value
 
 
 # Floating IP


### PR DESCRIPTION
Earlier only the validation for capability value - if the value for the capability already exists is checked when the capability is first assigned to the node.

Does not consider the case, when the value is updated for a node. Adding another method in models to check if any node has the same value for a capability when is_unique is True

Change-Id: I115a6de12cabc2e32b5c10669b0f9c7b0fdbb5f5