### PR TITLE
Resource details in a lease

### DIFF
--- a/blazar/api/v1/leases/service.py
+++ b/blazar/api/v1/leases/service.py
@@ -65,6 +65,15 @@ class API(object):
         """
         return self.manager_service.get_lease(lease_id)
 
+    @policy.authorize('leases', 'get')
+    def nodes_in_lease(self, lease_id):
+        """Get lease by its ID.
+
+        :param lease_id: ID of the lease in Blazar DB.
+        :type lease_id: str
+        """
+        return self.manager_service.nodes_in_lease(lease_id)
+
     @policy.authorize('leases', 'put')
     def update_lease(self, lease_id, data):
         """Update lease.

--- a/blazar/api/v1/leases/service.py
+++ b/blazar/api/v1/leases/service.py
@@ -66,13 +66,13 @@ class API(object):
         return self.manager_service.get_lease(lease_id)
 
     @policy.authorize('leases', 'get')
-    def nodes_in_lease(self, lease_id):
-        """List all nodes in lease by its ID.
+    def hosts_in_lease(self, lease_id):
+        """List all hosts in lease by its ID.
 
         :param lease_id: ID of the lease in Blazar DB.
         :type lease_id: str
         """
-        return self.manager_service.nodes_in_lease(lease_id)
+        return self.manager_service.hosts_in_lease(lease_id)
 
     @policy.authorize('leases', 'get')
     def networks_in_lease(self, lease_id):

--- a/blazar/api/v1/leases/service.py
+++ b/blazar/api/v1/leases/service.py
@@ -67,12 +67,30 @@ class API(object):
 
     @policy.authorize('leases', 'get')
     def nodes_in_lease(self, lease_id):
-        """Get lease by its ID.
+        """List all nodes in lease by its ID.
 
         :param lease_id: ID of the lease in Blazar DB.
         :type lease_id: str
         """
         return self.manager_service.nodes_in_lease(lease_id)
+
+    @policy.authorize('leases', 'get')
+    def networks_in_lease(self, lease_id):
+        """List all networks in lease by its ID.
+
+        :param lease_id: ID of the lease in Blazar DB.
+        :type lease_id: str
+        """
+        return self.manager_service.networks_in_lease(lease_id)
+
+    @policy.authorize('leases', 'get')
+    def devices_in_lease(self, lease_id):
+        """List all devices in lease by its ID.
+
+        :param lease_id: ID of the lease in Blazar DB.
+        :type lease_id: str
+        """
+        return self.manager_service.devices_in_lease(lease_id)
 
     @policy.authorize('leases', 'put')
     def update_lease(self, lease_id, data):

--- a/blazar/api/v1/leases/v1_0.py
+++ b/blazar/api/v1/leases/v1_0.py
@@ -68,20 +68,20 @@ def leases_delete(req, lease_id):
     return api_utils.render(status=200)
 
 
-@rest.get('/leases/<lease_id>/nodes')
-def nodes_in_lease_get(req, lease_id):
-    """Get nodes in lease by its ID."""
-    return api_utils.render(nodes=_api.nodes_in_lease(lease_id))
+@rest.get('/leases/<lease_id>/hosts')
+def hosts_in_lease_get(req, lease_id):
+    """Get hosts in lease by its ID."""
+    return api_utils.render(hosts=_api.hosts_in_lease(lease_id))
 
 @rest.get('/leases/<lease_id>/networks')
 def networks_in_lease_get(req, lease_id):
     """Get networks in lease by its ID."""
-    return api_utils.render(nodes=_api.networks_in_lease(lease_id))
+    return api_utils.render(networks=_api.networks_in_lease(lease_id))
 
 @rest.get('/leases/<lease_id>/devices')
 def devices_in_lease_get(req, lease_id):
     """Get devices in lease by its ID."""
-    return api_utils.render(nodes=_api.devices_in_lease(lease_id))
+    return api_utils.render(devices=_api.devices_in_lease(lease_id))
 
 
 # Plugins operations

--- a/blazar/api/v1/leases/v1_0.py
+++ b/blazar/api/v1/leases/v1_0.py
@@ -68,6 +68,12 @@ def leases_delete(req, lease_id):
     return api_utils.render(status=200)
 
 
+@rest.get('/leases/<lease_id>/nodes')
+def nodes_in_lease_get(req, lease_id):
+    """Get nodes in lease by its ID."""
+    return api_utils.render(nodes=_api.nodes_in_lease(lease_id))
+
+
 # Plugins operations
 
 @rest.get('/plugins')

--- a/blazar/api/v1/leases/v1_0.py
+++ b/blazar/api/v1/leases/v1_0.py
@@ -73,6 +73,16 @@ def nodes_in_lease_get(req, lease_id):
     """Get nodes in lease by its ID."""
     return api_utils.render(nodes=_api.nodes_in_lease(lease_id))
 
+@rest.get('/leases/<lease_id>/networks')
+def networks_in_lease_get(req, lease_id):
+    """Get networks in lease by its ID."""
+    return api_utils.render(nodes=_api.networks_in_lease(lease_id))
+
+@rest.get('/leases/<lease_id>/devices')
+def devices_in_lease_get(req, lease_id):
+    """Get devices in lease by its ID."""
+    return api_utils.render(nodes=_api.devices_in_lease(lease_id))
+
 
 # Plugins operations
 

--- a/blazar/db/api.py
+++ b/blazar/db/api.py
@@ -179,9 +179,9 @@ def lease_get(lease_id):
 
 
 @to_dict
-def nodes_in_lease(lease_id):
-    """Return nodes in a lease."""
-    return IMPL.nodes_in_lease(lease_id)
+def hosts_in_lease(lease_id):
+    """Return hosts in a lease."""
+    return IMPL.hosts_in_lease(lease_id)
 
 
 @to_dict

--- a/blazar/db/api.py
+++ b/blazar/db/api.py
@@ -179,6 +179,12 @@ def lease_get(lease_id):
 
 
 @to_dict
+def nodes_in_lease(lease_id):
+    """Return nodes in a lease."""
+    return IMPL.nodes_in_lease(lease_id)
+
+
+@to_dict
 def lease_list(project_id=None):
     """Return a list of all existing leases."""
     return IMPL.lease_list(project_id)

--- a/blazar/db/api.py
+++ b/blazar/db/api.py
@@ -185,6 +185,18 @@ def nodes_in_lease(lease_id):
 
 
 @to_dict
+def networks_in_lease(lease_id):
+    """Return networks in a lease."""
+    return IMPL.networks_in_lease(lease_id)
+
+
+@to_dict
+def devices_in_lease(lease_id):
+    """Return devices in a lease."""
+    return IMPL.devices_in_lease(lease_id)
+
+
+@to_dict
 def lease_list(project_id=None):
     """Return a list of all existing leases."""
     return IMPL.lease_list(project_id)

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -256,7 +256,7 @@ def lease_get_all_by_user(user_id):
     raise NotImplementedError
 
 
-def nodes_in_lease(lease_id):
+def hosts_in_lease(lease_id):
     query = model_query(models.ComputeHost, get_session())
     query = query.join(
         models.ComputeHostAllocation,

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -278,7 +278,7 @@ def devices_in_lease(lease_id):
     query = model_query(models.Device, get_session())
     query = query.join(
         models.DeviceAllocation,
-        models.DeviceAllocation.compute_host_id == models.Device.id
+        models.DeviceAllocation.device_id == models.Device.id
     ).join(
         models.DeviceReservation,
         models.DeviceReservation.reservation_id == models.DeviceAllocation.reservation_id
@@ -296,7 +296,7 @@ def networks_in_lease(lease_id):
     query = model_query(models.NetworkSegment, get_session())
     query = query.join(
         models.NetworkAllocation,
-        models.NetworkAllocation.compute_host_id == models.NetworkSegment.id
+        models.NetworkAllocation.network_id == models.NetworkSegment.id
     ).join(
         models.NetworkReservation,
         models.NetworkReservation.reservation_id == models.NetworkAllocation.reservation_id

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -256,6 +256,24 @@ def lease_get_all_by_user(user_id):
     raise NotImplementedError
 
 
+def nodes_in_lease(lease_id):
+    query = model_query(models.ComputeHost, get_session())
+    query = query.join(
+        models.ComputeHostAllocation,
+        models.ComputeHostAllocation.compute_host_id == models.ComputeHost.id
+    ).join(
+        models.ComputeHostReservation,
+        models.ComputeHostReservation.reservation_id == models.ComputeHostAllocation.reservation_id
+    ).join(
+        models.Reservation,
+        models.Reservation.id == models.ComputeHostReservation.reservation_id
+    ).join(
+        models.Lease,
+        models.Lease.id == models.Reservation.lease_id
+    ).filter(models.Lease.id == lease_id)
+    return query.all()
+
+
 def lease_list(project_id=None):
     query = model_query(models.Lease, get_session())
     if project_id is not None:

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -274,6 +274,42 @@ def nodes_in_lease(lease_id):
     return query.all()
 
 
+def devices_in_lease(lease_id):
+    query = model_query(models.Device, get_session())
+    query = query.join(
+        models.DeviceAllocation,
+        models.DeviceAllocation.compute_host_id == models.Device.id
+    ).join(
+        models.DeviceReservation,
+        models.DeviceReservation.reservation_id == models.DeviceAllocation.reservation_id
+    ).join(
+        models.Reservation,
+        models.Reservation.id == models.DeviceReservation.reservation_id
+    ).join(
+        models.Lease,
+        models.Lease.id == models.Reservation.lease_id
+    ).filter(models.Lease.id == lease_id)
+    return query.all()
+
+
+def networks_in_lease(lease_id):
+    query = model_query(models.NetworkSegment, get_session())
+    query = query.join(
+        models.NetworkAllocation,
+        models.NetworkAllocation.compute_host_id == models.NetworkSegment.id
+    ).join(
+        models.NetworkReservation,
+        models.NetworkReservation.reservation_id == models.NetworkAllocation.reservation_id
+    ).join(
+        models.Reservation,
+        models.Reservation.id == models.NetworkReservation.reservation_id
+    ).join(
+        models.Lease,
+        models.Lease.id == models.Reservation.lease_id
+    ).filter(models.Lease.id == lease_id)
+    return query.all()
+
+
 def lease_list(project_id=None):
     query = model_query(models.Lease, get_session())
     if project_id is not None:

--- a/blazar/manager/leases/rpcapi.py
+++ b/blazar/manager/leases/rpcapi.py
@@ -46,9 +46,9 @@ class ManagerRPCAPI(service.RPCClient):
         """Delete specified lease."""
         return self.call('delete_lease', lease_id=lease_id)
 
-    def nodes_in_lease(self, lease_id):
-        """List all nodes in lease by its ID."""
-        return self.call('nodes_in_lease', lease_id=lease_id)
+    def hosts_in_lease(self, lease_id):
+        """List all hosts in lease by its ID."""
+        return self.call('hosts_in_lease', lease_id=lease_id)
 
     def networks_in_lease(self, lease_id):
         """List all networks in lease by its ID."""

--- a/blazar/manager/leases/rpcapi.py
+++ b/blazar/manager/leases/rpcapi.py
@@ -45,3 +45,15 @@ class ManagerRPCAPI(service.RPCClient):
     def delete_lease(self, lease_id):
         """Delete specified lease."""
         return self.call('delete_lease', lease_id=lease_id)
+
+    def nodes_in_lease(self, lease_id):
+        """List all nodes in lease by its ID."""
+        return self.call('nodes_in_lease', lease_id=lease_id)
+
+    def networks_in_lease(self, lease_id):
+        """List all networks in lease by its ID."""
+        return self.call('networks_in_lease', lease_id=lease_id)
+
+    def devices_in_lease(self, lease_id):
+        """List all devices in lease by its ID."""
+        return self.call('devices_in_lease', lease_id=lease_id)

--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -324,6 +324,12 @@ class ManagerService(service_utils.RPCServer):
     def nodes_in_lease(self, lease_id):
         return db_api.nodes_in_lease(lease_id)
 
+    def networks_in_lease(self, lease_id):
+        return db_api.networks_in_lease(lease_id)
+
+    def devices_in_lease(self, lease_id):
+        return db_api.devices_in_lease(lease_id)
+
     def list_leases(self, project_id=None, query=None):
         return db_api.lease_list(project_id)
 

--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -321,6 +321,9 @@ class ManagerService(service_utils.RPCServer):
     def get_lease(self, lease_id):
         return db_api.lease_get(lease_id)
 
+    def nodes_in_lease(self, lease_id):
+        return db_api.nodes_in_lease(lease_id)
+
     def list_leases(self, project_id=None, query=None):
         return db_api.lease_list(project_id)
 

--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -321,8 +321,8 @@ class ManagerService(service_utils.RPCServer):
     def get_lease(self, lease_id):
         return db_api.lease_get(lease_id)
 
-    def nodes_in_lease(self, lease_id):
-        return db_api.nodes_in_lease(lease_id)
+    def hosts_in_lease(self, lease_id):
+        return db_api.hosts_in_lease(lease_id)
 
     def networks_in_lease(self, lease_id):
         return db_api.networks_in_lease(lease_id)

--- a/blazar/policies/leases.py
+++ b/blazar/policies/leases.py
@@ -29,6 +29,10 @@ leases_policies = [
             {
                 'path': '/{api_version}/leases/{lease_id}',
                 'method': 'GET'
+            },
+            {
+                'path': '/{api_version}/leases/{lease_id}/nodes',
+                'method': 'GET'
             }
         ]
     ),

--- a/blazar/policies/leases.py
+++ b/blazar/policies/leases.py
@@ -31,7 +31,7 @@ leases_policies = [
                 'method': 'GET'
             },
             {
-                'path': '/{api_version}/leases/{lease_id}/nodes',
+                'path': '/{api_version}/leases/{lease_id}/hosts',
                 'method': 'GET'
             },
             {

--- a/blazar/policies/leases.py
+++ b/blazar/policies/leases.py
@@ -33,6 +33,14 @@ leases_policies = [
             {
                 'path': '/{api_version}/leases/{lease_id}/nodes',
                 'method': 'GET'
+            },
+            {
+                'path': '/{api_version}/leases/{lease_id}/networks',
+                'method': 'GET'
+            },
+            {
+                'path': '/{api_version}/leases/{lease_id}/devices',
+                'method': 'GET'
             }
         ]
     ),


### PR DESCRIPTION
Add new blazar api endpoint for hosts in lease

This addresses the complexity and inefficiency of the existing method for obtaining current nodes
in a lease in Blazar. Previously, this process involved making two large-volume API calls to
fetch all hosts and allocations in Blazar, which resulted in delays and negatively impacted downstream implementations.

To streamline this process and improve efficiency, a new API endpoint,
`reservation/v1/leases/<lease_id>/hosts`, has been introduced to Blazar leases.
This endpoint provides the Blazar host IDs and hypervisor hostnames associated with the specified lease ID.

This further extends to get `networks` and `devices`

By offering this functionality, operators and TMs can now obtain information about the nodes allocated
to a lease with a single api call, significantly reducing the time required.
Additionally, this change aims to enhance the loading speed of the lease details page in Horizon,
thereby improving the overall user experience.