### PR TITLE
Wip/idempotent host create

### DIFF
--- a/blazar/exceptions.py
+++ b/blazar/exceptions.py
@@ -62,6 +62,9 @@ class NotAuthorized(BlazarException):
     msg_fmt = _("Not authorized")
     code = 403
 
+class Conflict(BlazarException):
+    msg_fmt = _("Conflict with %(object)s")
+    code = 409
 
 class PolicyNotAuthorized(NotAuthorized):
     msg_fmt = _("Policy doesn't allow %(action)s to be performed")

--- a/blazar/manager/exceptions.py
+++ b/blazar/manager/exceptions.py
@@ -59,6 +59,8 @@ class AggregateNotFound(exceptions.NotFound):
 class HostNotFound(exceptions.NotFound):
     msg_fmt = _("Host '%(host)s' not found!")
 
+class DuplicateHost(exceptions.Conflict):
+    msg_fmt = _("Host %(host)s already exists")
 
 class InvalidHost(exceptions.NotAuthorized):
     msg_fmt = _("Invalid values for host %(host)s")

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -335,6 +335,12 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         for host in raw_host_list:
             host_list.append(self.get_computehost(host['id']))
         return host_list
+    
+    def _host_exists(self, host_name_or_id):
+        # TODO: This is where we need to decide what a conflict is
+        # are different UUIDs with same "name" OK? what about different names, but 
+        # referring to the same placement resource?
+        raise NotImplementedError
 
     def create_computehost(self, host_values):
         # TODO(sbauza):
@@ -349,6 +355,13 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         host_ref = host_id or host_name
         if host_ref is None:
             raise manager_ex.InvalidHost(host=host_values)
+        elif(self._host_exists(host_ref)):
+            # TODO: this exception should probably contain the existing host, 
+            # not the one we're trying to make
+            # TODO if we don't make a check here, nothing guarantees we can't have 
+            # multiple reservation hosts for the same placement resource.
+            # the DB should probably enforce this, 
+            raise manager_ex.DuplicateHost(host=host_values)            
 
         inventory = nova.NovaInventory()
         servers = inventory.get_servers_per_host(host_ref)

--- a/blazar/utils/openstack/nova.py
+++ b/blazar/utils/openstack/nova.py
@@ -270,8 +270,7 @@ class ReservationPool(NovaClientWrapper):
                 except nova_exception.NotFound:
                     raise manager_exceptions.HostNotFound(host=host)
                 except nova_exception.Conflict as e:
-                    raise manager_exceptions.AggregateAlreadyHasHost(
-                        pool=pool, host=host, nova_exception=str(e))
+                    LOG.warning(f"Host {host} is already in aggregate id {agg.id}, continuing anyway")
 
                 # remove preemptible instances
                 for server in self.nova.servers.list(


### PR DESCRIPTION
this is an attempt to make blazar host create (and delete) more reliable.

Several resources must be in sync:

1. The blazar "host" db item
2. placement's resource provider for the blazar host `blazar_<ironic_uuid>`, with parent `ironic_uuid`
3. the nova aggregate entry for `ironic_uuid` in freepool

If these get out of sync, blazar host creation or deletion for the affected ironic host will fail. This is particularly common when enrolling/re-enrolling nodes.

For this PR, I claim that "if the resource is already in the desired state, don't fail".
e.g. "if the ironic host is already in the correct aggregate, proceed instead of raise.
and: "if the placement resource provider already exists, AND has the values we would have put on it, proceed instead of raise".

Unfortunately, it turns out that the conflict error on the placement resource is the only thing that keeps us from making duplicate reservation host objects.

The TODO part of this work is: How should uniqueness of host objects be enforced?
I propose that exactly one blazar host object should be able to refer to a given placement resource, but we need to make sure this doesn't cause issues with VM reservation, or potential reservation of heirarchical objects, such as composable hardware with multiple GPUs. We can choose to follow placement's approach, in that we must target a placement "child' object for that many-to-one relationship.


