### PR TITLE
Use user token in external enforcement if not configured

### DIFF
--- a/blazar/enforcement/enforcement.py
+++ b/blazar/enforcement/enforcement.py
@@ -55,6 +55,7 @@ class UsageEnforcement:
         region_name = CONF.os_region_name
         auth_url = base.url_for(
             ctx['service_catalog'], CONF.identity_service,
+            endpoint_interface="public",
             os_region_name=region_name)
 
         return dict(user_id=lease_values['user_id'],

--- a/blazar/enforcement/filters/external_service_filter.py
+++ b/blazar/enforcement/filters/external_service_filter.py
@@ -23,6 +23,7 @@ from blazar.enforcement.exceptions import ExternalServiceFilterException
 from blazar.enforcement.filters import base_filter
 from blazar.exceptions import BlazarException
 from blazar.i18n import _
+from blazar.utils.openstack.keystone import BlazarKeystoneClient
 
 from oslo_config import cfg
 from oslo_log import log as logging
@@ -96,7 +97,12 @@ class ExternalServiceFilter(base_filter.BaseFilter):
             raise ExternalServiceMisconfigured(
                 message=_("ExternalService has no endpoints set."))
 
-        self.token = conf.enforcement.external_service_token
+        if conf.enforcement.external_service_token:
+            self.token = (self.external_service_token)
+        else:
+            client = BlazarKeystoneClient()
+            self.token = client.session.get_token()
+
 
     @staticmethod
     def _validate_url(url):


### PR DESCRIPTION
In xena, we had this conditional code to fetch a user token https://github.com/ChameleonCloud/blazar/blob/chameleoncloud/xena/blazar/enforcement/filters/external_service_filter.py#L85-L86

This also gets the external identity endpoint, which is required because our "external service" is not in openstack.

Note: This breaks tests, as it tries to now reach out to keystone to get a token.