### PR TITLE
Fix healing during a lease

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -1010,7 +1010,7 @@ class PhysicalHostMonitorPlugin(monitor.GeneralMonitorPlugin,
                                      in failed_bm_ids])
                 active_bm_ids = [n.uuid for n in nodes
                                  if not n.maintenance
-                                 and n.provision_state in ['available']]
+                                 and n.provision_state in ['available', 'active']]
                 recovered_hosts.extend([host for host in unreservable_hosts
                                         if host['hypervisor_hostname']
                                         in active_bm_ids])


### PR DESCRIPTION
If someone has an instance on a node, the provision state will be active. Before this fix, if a node failed, it would remain unreservable while there was an instance on it, preventing advance reservations.