### PR TITLE
Res id enforcement

### DIFF
--- a/blazar/enforcement/exceptions.py
+++ b/blazar/enforcement/exceptions.py
@@ -29,7 +29,7 @@ class MaxLeaseUpdateWindowException(exceptions.NotAuthorized):
                 'seconds of the leases current end time.')
 
 
-class ExternalServiceFilterException(exceptions.BlazarException):
+class ExternalServiceFilterException(exceptions.NotAuthorized):
     code = 400
     msg_fmt = _('%(message)s')
 

--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -375,12 +375,6 @@ class ManagerService(service_utils.RPCServer):
 
             allocations = self._allocation_candidates(
                 lease_values, reservations)
-            try:
-                self.enforcement.check_create(
-                    context.current(), lease_values, reservations, allocations)
-            except common_ex.NotAuthorized as e:
-                LOG.error("Enforcement checks failed. %s", str(e))
-                raise common_ex.NotAuthorized(e)
 
             events.append({'event_type': 'start_lease',
                            'time': start_date,
@@ -438,6 +432,13 @@ class ManagerService(service_utils.RPCServer):
                                       "lease. Rollback the lease and "
                                       "associated reservations")
                         db_api.lease_destroy(lease_id)
+
+                try:
+                    self.enforcement.check_create(
+                        context.current(), lease_values, reservations, allocations)
+                except common_ex.NotAuthorized as e:
+                    LOG.error("Enforcement checks failed. %s", str(e))
+                    raise common_ex.NotAuthorized(e)
 
                 try:
                     for event in events:

--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -425,7 +425,7 @@ class ManagerService(service_utils.RPCServer):
                         reservation['start_date'] = lease['start_date']
                         reservation['end_date'] = lease['end_date']
                         reservation['project_id'] = lease['project_id']
-                        self._create_reservation(reservation)
+                        reservation["id"] = self._create_reservation(reservation)
                 except Exception:
                     with save_and_reraise_exception():
                         LOG.exception("Failed to create reservation for a "
@@ -809,6 +809,7 @@ class ManagerService(service_utils.RPCServer):
         )
         db_api.reservation_update(reservation['id'],
                                   {'resource_id': resource_id})
+        return reservation["id"]
 
     def _allocation_candidates(self, lease, reservations):
         """Returns dict by resource type of reservation candidates."""

--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -438,6 +438,7 @@ class ManagerService(service_utils.RPCServer):
                         context.current(), lease_values, reservations, allocations)
                 except common_ex.NotAuthorized as e:
                     LOG.error("Enforcement checks failed. %s", str(e))
+                    db_api.lease_destroy(lease_id)
                     raise common_ex.NotAuthorized(e)
 
                 try:

--- a/blazar/tests/enforcement/filters/test_external_service_filter.py
+++ b/blazar/tests/enforcement/filters/test_external_service_filter.py
@@ -140,6 +140,8 @@ class ExternalServiceFilterTestCase(TestCase):
         CONF.set_override(
             'external_service_base_endpoint', 'http://localhost',
             group='enforcement')
+        CONF.set_override(
+            'external_service_token', 'test_token', group='enforcement')
         self.addCleanup(CONF.clear_override, 'external_service_base_endpoint',
                         group='enforcement')
 
@@ -163,7 +165,7 @@ class ExternalServiceFilterTestCase(TestCase):
         self.filter.check_create(self.ctx, self.lease)
         post_mock.assert_called_with(
             "http://localhost/check-create",
-            headers={'Content-Type': 'application/json'},
+            headers={'Content-Type': 'application/json', 'X-Auth-Token': 'test_token'},
             data='{"context": {"is_context": true}, '
                  '"lease": {"is_lease": true}}')
 
@@ -175,7 +177,7 @@ class ExternalServiceFilterTestCase(TestCase):
                           self.ctx, self.lease)
         post_mock.assert_called_with(
             "http://localhost/check-create",
-            headers={'Content-Type': 'application/json'},
+            headers={'Content-Type': 'application/json', 'X-Auth-Token': 'test_token'},
             data='{"context": {"is_context": true}, '
                  '"lease": {"is_lease": true}}')
 
@@ -187,7 +189,7 @@ class ExternalServiceFilterTestCase(TestCase):
                           self.ctx, self.lease)
         post_mock.assert_called_with(
             "http://localhost/check-create",
-            headers={'Content-Type': 'application/json'},
+            headers={'Content-Type': 'application/json', 'X-Auth-Token': 'test_token'},
             data='{"context": {"is_context": true}, '
                  '"lease": {"is_lease": true}}')
 
@@ -197,7 +199,7 @@ class ExternalServiceFilterTestCase(TestCase):
         self.filter.check_update(self.ctx, self.old_lease, self.lease)
         post_mock.assert_called_with(
             "http://localhost/check-update",
-            headers={'Content-Type': 'application/json'},
+            headers={'Content-Type': 'application/json', 'X-Auth-Token': 'test_token'},
             data='{"context": {"is_context": true}, '
                  '"current_lease": {"is_old_lease": true}, '
                  '"lease": {"is_lease": true}}')
@@ -210,7 +212,7 @@ class ExternalServiceFilterTestCase(TestCase):
                           self.ctx, self.old_lease, self.lease)
         post_mock.assert_called_with(
             "http://localhost/check-update",
-            headers={'Content-Type': 'application/json'},
+            headers={'Content-Type': 'application/json', 'X-Auth-Token': 'test_token'},
             data='{"context": {"is_context": true}, '
                  '"current_lease": {"is_old_lease": true}, '
                  '"lease": {"is_lease": true}}')
@@ -224,7 +226,7 @@ class ExternalServiceFilterTestCase(TestCase):
                           self.ctx, self.old_lease, self.lease)
         post_mock.assert_called_with(
             "http://localhost/check-update",
-            headers={'Content-Type': 'application/json'},
+            headers={'Content-Type': 'application/json', 'X-Auth-Token': 'test_token'},
             data='{"context": {"is_context": true}, '
                  '"current_lease": {"is_old_lease": true}, '
                  '"lease": {"is_lease": true}}')
@@ -235,18 +237,20 @@ class ExternalServiceFilterTestCase(TestCase):
         self.filter.on_end(self.ctx, self.lease)
         post_mock.assert_called_with(
             "http://localhost/on-end",
-            headers={'Content-Type': 'application/json'},
+            headers={'Content-Type': 'application/json', 'X-Auth-Token': 'test_token'},
             data='{"context": {"is_context": true}, '
                  '"lease": {"is_lease": true}}')
 
     @mock.patch("requests.post")
     def test_on_end_failure(self, post_mock):
+        CONF.set_override(
+            'external_service_token', 'test_token', group='enforcement')
         post_mock.return_value = FakeResponse500()
         self.assertRaises(ExternalServiceFilterException,
                           self.filter.on_end,
                           self.ctx, self.lease)
         post_mock.assert_called_with(
             "http://localhost/on-end",
-            headers={'Content-Type': 'application/json'},
+            headers={'Content-Type': 'application/json', 'X-Auth-Token': 'test_token'},
             data='{"context": {"is_context": true}, '
                  '"lease": {"is_lease": true}}')

--- a/blazar/tests/enforcement/filters/test_max_lease_duration_filter.py
+++ b/blazar/tests/enforcement/filters/test_max_lease_duration_filter.py
@@ -85,7 +85,7 @@ class MaxLeaseDurationTestCase(tests.TestCase):
             dict(
                 type='identity', endpoints=[
                     dict(
-                        interface='internal', region=self.region,
+                        interface='public', region=self.region,
                         url='https://fakeauth.com')
                 ]
             )

--- a/blazar/tests/enforcement/test_enforcement.py
+++ b/blazar/tests/enforcement/test_enforcement.py
@@ -116,7 +116,7 @@ class EnforcementTestCase(tests.TestCase):
             dict(
                 type='identity', endpoints=[
                     dict(
-                        interface='internal', region=self.region,
+                        interface='public', region=self.region,
                         url='https://fakeauth.com')
                 ]
             )

--- a/blazar/tests/manager/test_service.py
+++ b/blazar/tests/manager/test_service.py
@@ -764,6 +764,7 @@ class ServiceTestCase(tests.DBTestCase):
 
     def test_create_lease_with_filter_exception(self):
         lease_values = self.lease_values.copy()
+        self.lease_create.return_value = self.lease
 
         self.enforcement.check_create.side_effect = (
             enforcement_ex.MaxLeaseDurationException(lease_duration=200,
@@ -772,7 +773,7 @@ class ServiceTestCase(tests.DBTestCase):
         self.assertRaises(exceptions.NotAuthorized,
                           self.manager.create_lease,
                           lease_values=lease_values)
-        self.lease_create.assert_not_called()
+        self.assertEqual(1, self.lease_create.call_count)
 
     def test_update_lease_completed_lease_rename(self):
         lease_values = {'name': 'renamed'}


### PR DESCRIPTION
Changes in `blazar/manager/service.py` enable passing a reservation ID to external enforcement. This value is picked up by [this portal change](https://github.com/ChameleonCloud/portal/blob/master/balance_service/enforcement/usage_enforcement.py#L208-L214), which will use the ID instead of the hacky "TMP_RESOURCE" string we are currently using. The issue with the temporary IDs is if a user updates the lease before [this task](https://github.com/ChameleonCloud/portal/blob/89d27ccd0874d6a205c9646b669657aee55988ef/allocations/tasks.py#L301) gets the real reservation ID, the user gets and error that is hard for us to fix. 

Note: `ExternalServiceFilterException` used to be a subclass `exceptions.NotAuthorized` until the antelope merge. Ultimately, it didn't matter, since all that was affected was the return code (500 vs 403). However now that we are catching and destroying the lease when enforcement fails, we need this to be fixed.