### PR TITLE
Fix allocation list to use cleaning time

### DIFF
--- a/blazar/plugins/base.py
+++ b/blazar/plugins/base.py
@@ -15,6 +15,7 @@
 
 import abc
 import collections
+import datetime
 
 from blazar import context
 from blazar import policy
@@ -205,6 +206,11 @@ class BasePlugin(object, metaclass=abc.ABCMeta):
                     alloc["extras"]["user_name"] = \
                         lease_to_name[alloc["lease_id"]]
 
+    def add_allocation_cleaning_time(self, resource_allocations, cleaning_time):
+        for allocs in resource_allocations.values():
+            for alloc in allocs:
+                alloc["start_date"] = alloc["start_date"] - datetime.timedelta(minutes=cleaning_time)
+                alloc["end_date"] = alloc["end_date"] + datetime.timedelta(minutes=cleaning_time)
 
 class BaseMonitorPlugin(metaclass=abc.ABCMeta):
     """Base class of monitor plugin."""

--- a/blazar/plugins/devices/device_plugin.py
+++ b/blazar/plugins/devices/device_plugin.py
@@ -431,6 +431,7 @@ class DevicePlugin(base.BasePlugin):
         devices_allocations = self.query_device_allocations(devices_id_list,
                                                             **options)
         self.add_extra_allocation_info(devices_allocations)
+        self.add_allocation_cleaning_time(devices_allocations, CONF.cleaning_time)
         return [{"resource_id": device, "reservations": allocs}
                 for device, allocs in devices_allocations.items()]
 

--- a/blazar/plugins/networks/network_plugin.py
+++ b/blazar/plugins/networks/network_plugin.py
@@ -572,6 +572,7 @@ class NetworkPlugin(base.BasePlugin):
         network_allocations = self.query_network_allocations(network_id_list,
                                                              **options)
         self.add_extra_allocation_info(network_allocations)
+        self.add_allocation_cleaning_time(network_allocations, CONF.cleaning_time)
         return [{"resource_id": network, "reservations": allocs}
                 for network, allocs in network_allocations.items()]
 

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -573,6 +573,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         options['detail'] = detail
         host_allocations = self.query_host_allocations([host_id], **options)
         allocs = host_allocations.get(host_id, [])
+        self.add_allocation_cleaning_time({host_id: allocs}, CONF.cleaning_time)
         return {"resource_id": host_id, "reservations": allocs}
 
     def reallocate_computehost(self, host_id, data):

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -564,6 +564,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         hosts_allocations = self.query_host_allocations(hosts_id_list,
                                                         **options)
         self.add_extra_allocation_info(hosts_allocations)
+        self.add_allocation_cleaning_time(hosts_allocations, CONF.cleaning_time)
         return [{"resource_id": host, "reservations": allocs}
                 for host, allocs in hosts_allocations.items()]
 

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -530,7 +530,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                 'reservations': [
                     {'id': 'reservation-1',
                         'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                        'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                 ]
             },
             {
@@ -538,10 +538,10 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                 'reservations': [
                     {'id': 'reservation-1',
                         'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                        'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                     {'id': 'reservation-2',
                         'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                        'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                 ]
             },
             {
@@ -549,7 +549,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                 'reservations': [
                     {'id': 'reservation-2',
                         'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                        'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                 ]
             }
         ]
@@ -582,7 +582,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                 'reservations': [
                     {'id': 'reservation-1',
                         'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                        'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                 ]
             },
             {
@@ -590,7 +590,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                 'reservations': [
                     {'id': 'reservation-1',
                         'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                        'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                 ]
             },
         ]
@@ -626,9 +626,9 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             'resource_id': 'host-1',
             'reservations': [
                 {'id': 'reservation-1', 'lease_id': 'lease-1',
-                    'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                    'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                 {'id': 'reservation-3', 'lease_id': 'lease-2',
-                    'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                    'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
             ]
         }
         ret = self.fake_phys_plugin.get_allocations('host-1', {})

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -184,7 +184,8 @@ class PhysicalHostPluginTestCase(tests.TestCase):
     def reservation_allocation_dict(self, r_id, l_id, p_id, h_ids):
         return {
             'id': r_id, 'status': 'active', 'lease_id': l_id,
-            'start_date': '2015-01-01', 'end_date': '2015-01-02',
+            'start_date': datetime.datetime(2015, 1, 1, 0, 0),
+            'end_date': datetime.datetime(2015, 1, 2, 0, 0),
             'lease_name': l_id, 'project_id': p_id,
             'host_ids': h_ids}
 
@@ -472,10 +473,10 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                 'reservations': [
                     {'id': 'reservation-1',
                         'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                        'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                     {'id': 'reservation-3',
                         'lease_id': 'lease-2', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                        'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                 ]
             },
             {
@@ -483,10 +484,10 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                 'reservations': [
                     {'id': 'reservation-1',
                         'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                        'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                     {'id': 'reservation-2',
                         'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                        'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                 ]
             },
             {
@@ -494,7 +495,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                 'reservations': [
                     {'id': 'reservation-2',
                         'lease_id': 'lease-1', 'extras': {},
-                        'start_date': '2015-01-01', 'end_date': '2015-01-02'},
+                        'start_date': datetime.datetime(2015, 1, 1), 'end_date': datetime.datetime(2015, 1, 2)},
                 ]
             }
         ]
@@ -655,7 +656,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             'resource_id': 'host-1',
             'reservations': [
                 {'id': 'reservation-1', 'lease_id': 'lease-1',
-                    'start_date': '2015-01-01', 'end_date': '2015-01-02'}]}
+                    'start_date': datetime.datetime(2015, 1, 1, 0, 0), 'end_date': datetime.datetime(2015, 1, 2, 0, 0)}]}
 
         ret = self.fake_phys_plugin.get_allocations('host-1',
                                                     {'lease_id': 'lease-1'})
@@ -681,7 +682,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             'resource_id': 'host-1',
             'reservations': [
                 {'id': 'reservation-1', 'lease_id': 'lease-1',
-                    'start_date': '2015-01-01', 'end_date': '2015-01-02'}]}
+                    'start_date': datetime.datetime(2015, 1, 1, 0, 0), 'end_date': datetime.datetime(2015, 1, 2, 0, 0)}]}
 
         ret = self.fake_phys_plugin.get_allocations(
             'host-1', {'reservation_id': 'reservation-1'})


### PR DESCRIPTION
Cleaning time was not useful before, as it broke user workflows around allocation list. This changes the allocation information to add the cleaning time buffer, so that user workflows can be preserved (both seeing free timeslots on the calendar and via python-chi).
