### PR TITLE
Fix randomization

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -15,7 +15,7 @@
 # under the License.
 
 import datetime
-from random import Random
+import random
 
 from novaclient import exceptions as nova_exceptions
 from oslo_config import cfg
@@ -733,12 +733,12 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                 allocated_host_ids.append(host['id'])
         if len(not_allocated_host_ids) >= int(min_host):
             if CONF[self.resource_type].randomize_host_selection:
-                Random.shuffle(not_allocated_host_ids)
+                random.shuffle(not_allocated_host_ids)
             return not_allocated_host_ids[:int(max_host)]
         all_host_ids = allocated_host_ids + not_allocated_host_ids
         if len(all_host_ids) >= int(min_host):
             if CONF[self.resource_type].randomize_host_selection:
-                Random.shuffle(all_host_ids)
+                random.shuffle(all_host_ids)
             return all_host_ids[:int(max_host)]
         else:
             return []

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -2492,7 +2492,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         self.addCleanup(CONF.clear_override, 'cleaning_time')
         self.assertEqual(['host1', 'host2', 'host3'], result)
 
-    @mock.patch.object(random.Random, "shuffle")
+    @mock.patch.object(random, "shuffle")
     def test_random_matching_hosts_not_allocated_hosts(self, mock_shuffle):
         def host_allocation_get_all_by_values(**kwargs):
             if kwargs['compute_host_id'] == 'host1':
@@ -2531,7 +2531,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                         group=plugin.RESOURCE_TYPE)
         mock_shuffle.assert_called_once_with(['host2', 'host3'])
 
-    @mock.patch.object(random.Random, "shuffle")
+    @mock.patch.object(random, "shuffle")
     def test_random_matching_hosts_allocated_hosts(self, mock_shuffle):
         def host_allocation_get_all_by_values(**kwargs):
             if kwargs['compute_host_id'] == 'host1':
@@ -2570,7 +2570,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                         group=plugin.RESOURCE_TYPE)
         mock_shuffle.assert_called_once_with(['host1', 'host2', 'host3'])
 
-    @mock.patch.object(random.Random, "shuffle")
+    @mock.patch.object(random, "shuffle")
     def test_random_matching_hosts_allocated_cleaning_time(self, mock_shuffle):
         def host_allocation_get_all_by_values(**kwargs):
             if kwargs['compute_host_id'] == 'host1':

--- a/releasenotes/notes/fix-host-randomization-bcab5276ef6199e6.yaml
+++ b/releasenotes/notes/fix-host-randomization-bcab5276ef6199e6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes functionality of host randomization feature.
+    `LP#2099927 <https://bugs.launchpad.net/blazar/+bug/2099927>`__


### PR DESCRIPTION
Previously, this was implemented using the shuffle method of the Random class without instantiating a Random object, which did not work. This changes swaps to the random.shuffle method, which works as expected.

Closes-Bug: #2099927
Change-Id: Ib288091af9cc035ccb0535fbc1748c17bb3cb1e9

Note: Backported from upstream into this branch.
