### PR TITLE
Improve host reallocation

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -286,15 +286,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
             lease['project_id'],
             allow_unreservable=False, # Don't reallocate to an unreservable host in this case
         )
-        ret = None
-        if not new_hostids:
-            # Only delete the failed re-allocation if forced
-            if force:
-                db_api.host_allocation_destroy(allocation['id'])
-            LOG.warn('Could not find alternative host for reservation %s '
-                     '(lease: %s).', reservation['id'], lease['name'])
-            ret = False
-        else:
+        if new_hostids:
             new_hostid = new_hostids.pop()
             db_api.host_allocation_update(allocation['id'],
                                           {'compute_host_id': new_hostid})
@@ -305,13 +297,22 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                 new_host = db_api.host_get(new_hostid)
                 pool.add_computehost(h_reservation['aggregate_id'],
                                      new_host['hypervisor_hostname'])
-            ret = True
-        if force or ret:
-            # Remove the old host from the pool
+                pool.remove_computehost(h_reservation['aggregate_id'],
+                            old_host['hypervisor_hostname'])
+            return True
+        elif force:
+            # If we are forcing reallocation from this host,
+            # destroy the old allocation and update pool.
+            LOG.warn('Forcing reservation %s off host %s'
+                '(lease: %s).', reservation['id'], old_host['hypervisor_hostname'], lease['name'])
+            db_api.host_allocation_destroy(allocation['id'])
             pool.remove_computehost(h_reservation['aggregate_id'],
                                     old_host['hypervisor_hostname'])
-
-        return ret
+            return False
+        else:
+            LOG.warn('Could not find alternative host for reservation %s '
+                     '(lease: %s).', reservation['id'], lease['name'])
+            return False
 
     def _get_extra_capabilities(self, host_id):
         extra_capabilities = {}

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -253,10 +253,11 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         except manager_ex.AggregateNotFound:
             pass
 
-    def _reallocate(self, allocation):
+    def _reallocate(self, allocation, force=False, reallocate_to=None):
         """Allocate an alternative host.
 
         :param allocation: allocation to change.
+        :param force: Force reallocation off a host even if no other host is available
         :return: True if an alternative host was successfully allocated.
         """
         reservation = db_api.reservation_get(allocation['reservation_id'])
@@ -265,20 +266,16 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         lease = db_api.lease_get(reservation['lease_id'])
         pool = nova.ReservationPool()
 
-        # Remove the old host from the aggregate.
+        # Check for servers. We cannot reallocate active servers
+        old_host = db_api.host_get(allocation['compute_host_id'])
         if reservation['status'] == status.reservation.ACTIVE:
-            host = db_api.host_get(allocation['compute_host_id'])
-
             servers = self.nova.servers.list(search_opts={
-                "node": host['hypervisor_hostname'], "all_tenants": 1})
+                "node": old_host['hypervisor_hostname'], "all_tenants": 1})
             if len(servers) != 0:
                 raise manager_ex.HostHavingServers(
                     servers=[s.name for s in servers],
-                    host=host['hypervisor_hostname']
+                    host=old_host['hypervisor_hostname']
                 )
-
-            pool.remove_computehost(h_reservation['aggregate_id'],
-                                    host['hypervisor_hostname'])
 
         # Allocate an alternative host.
         start_date = max(datetime.datetime.utcnow(), lease['start_date'])
@@ -287,12 +284,22 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
             reservation['resource_properties'],
             '1-1', start_date, lease['end_date'],
             lease['project_id'],
+            allow_unreservable=False, # Don't reallocate to an unreservable host in this case
         )
+        # If the user specifies a "to" host, only consider that
+        if reallocate_to:
+            if reallocate_to in new_hostids:
+                new_hostids = [reallocate_to]
+            else:
+                new_hostids = []
+        ret = None
         if not new_hostids:
-            db_api.host_allocation_destroy(allocation['id'])
+            # Only delete the failed re-allocation if forced
+            if force:
+                db_api.host_allocation_destroy(allocation['id'])
             LOG.warn('Could not find alternative host for reservation %s '
                      '(lease: %s).', reservation['id'], lease['name'])
-            return False
+            ret = False
         else:
             new_hostid = new_hostids.pop()
             db_api.host_allocation_update(allocation['id'],
@@ -304,8 +311,13 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                 new_host = db_api.host_get(new_hostid)
                 pool.add_computehost(h_reservation['aggregate_id'],
                                      new_host['hypervisor_hostname'])
+            ret = True
+        if force or ret:
+            # Remove the old host from the pool
+            pool.remove_computehost(h_reservation['aggregate_id'],
+                                    old_host['hypervisor_hostname'])
 
-            return True
+        return ret
 
     def _get_extra_capabilities(self, host_id):
         extra_capabilities = {}
@@ -576,6 +588,8 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
 
     def reallocate_computehost(self, host_id, data):
         lease_id = data.get('lease_id')
+        force = data.get("force", False)
+        reallocate_to = data.get("reallocate_to", None)
         if lease_id:
             # If we're only reallocating a host for a single lease,
             # then we allow non-admin users to perform this action,
@@ -600,11 +614,12 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                 compute_host_id=host_id,
                 reservation_id=alloc['id'])[0]
 
-            if self._reallocate(host_allocation):
+            if self._reallocate(host_allocation, force=force, reallocate_to=reallocate_to):
                 if alloc['status'] == status.reservation.ACTIVE:
                     reservation_flags.update(dict(resources_changed=True))
                     db_api.lease_update(alloc['lease_id'], dict(degraded=True))
-            else:
+            elif force:
+                # Resources are only missing if reallocated failed, and force was used
                 reservation_flags.update(dict(missing_resources=True))
                 db_api.lease_update(alloc['lease_id'], dict(degraded=True))
 
@@ -689,7 +704,8 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
             return False
 
     def _matching_hosts(self, hypervisor_properties, resource_properties,
-                        count_range, start_date, end_date, project_id):
+                        count_range, start_date, end_date, project_id,
+                        allow_unreservable=True):
         """Return the matching hosts (preferably not allocated)
 
         """
@@ -712,7 +728,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
             filter_array += plugins_utils.convert_requirements(
                 resource_properties)
         # admin can create a lease for host with 'reservable' False
-        if self._is_admin():
+        if self._is_admin() and allow_unreservable:
             hosts = db_api.host_get_all_by_queries(filter_array)
         else:
             hosts = db_api.reservable_host_get_all_by_queries(filter_array)

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -253,7 +253,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         except manager_ex.AggregateNotFound:
             pass
 
-    def _reallocate(self, allocation, force=False, reallocate_to=None):
+    def _reallocate(self, allocation, force=False):
         """Allocate an alternative host.
 
         :param allocation: allocation to change.
@@ -286,12 +286,6 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
             lease['project_id'],
             allow_unreservable=False, # Don't reallocate to an unreservable host in this case
         )
-        # If the user specifies a "to" host, only consider that
-        if reallocate_to:
-            if reallocate_to in new_hostids:
-                new_hostids = [reallocate_to]
-            else:
-                new_hostids = []
         ret = None
         if not new_hostids:
             # Only delete the failed re-allocation if forced
@@ -589,7 +583,6 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
     def reallocate_computehost(self, host_id, data):
         lease_id = data.get('lease_id')
         force = data.get("force", False)
-        reallocate_to = data.get("reallocate_to", None)
         if lease_id:
             # If we're only reallocating a host for a single lease,
             # then we allow non-admin users to perform this action,
@@ -614,7 +607,7 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                 compute_host_id=host_id,
                 reservation_id=alloc['id'])[0]
 
-            if self._reallocate(host_allocation, force=force, reallocate_to=reallocate_to):
+            if self._reallocate(host_allocation, force=force):
                 if alloc['status'] == status.reservation.ACTIVE:
                     reservation_flags.update(dict(resources_changed=True))
                     db_api.lease_update(alloc['lease_id'], dict(degraded=True))

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -2266,62 +2266,6 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             {'compute_host_id': new_host['id']})
         self.assertEqual(True, result)
 
-    def test_reallocate_before_start_reallocate_to(self):
-        failed_host = {'id': '1'}
-        new_host = {'id': '2'}
-        dummy_allocation = {
-            'id': 'alloc-1',
-            'compute_host_id': failed_host['id'],
-            'reservation_id': 'rsrv-1',
-        }
-        dummy_reservation = {
-            'id': 'rsrv-1',
-            'resource_type': plugin.RESOURCE_TYPE,
-            'lease_id': 'lease-1',
-            'status': 'pending',
-            'hypervisor_properties': [],
-            'resource_properties': [],
-            'resource_id': 'resource-1'
-        }
-        dummy_host_reservation = {
-            'aggregate_id': 1
-        }
-        dummy_lease = {
-            'name': 'lease-name',
-            'start_date': datetime.datetime(2020, 1, 1, 12, 00),
-            'end_date': datetime.datetime(2020, 1, 2, 12, 00),
-            'trust_id': 'trust-1',
-            'project_id': 'fake-project'
-        }
-        reservation_get = self.patch(self.db_api, 'reservation_get')
-        reservation_get.return_value = dummy_reservation
-        host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
-        host_reservation_get.return_value = dummy_host_reservation
-        lease_get = self.patch(self.db_api, 'lease_get')
-        lease_get.return_value = dummy_lease
-        matching_hosts = self.patch(host_plugin.PhysicalHostPlugin,
-                                    '_matching_hosts')
-        matching_hosts.return_value = ["fake_host_id_1", new_host['id'], "fake_host_id_2"]
-        alloc_update = self.patch(self.db_api, 'host_allocation_update')
-
-        with mock.patch.object(datetime, 'datetime',
-                               mock.Mock(wraps=datetime.datetime)) as patched:
-            patched.utcnow.return_value = datetime.datetime(
-                2020, 1, 1, 11, 00)
-            result = self.fake_phys_plugin._reallocate(dummy_allocation, reallocate_to=new_host['id'])
-
-        matching_hosts.assert_called_once_with(
-            dummy_reservation['hypervisor_properties'],
-            dummy_reservation['resource_properties'],
-            '1-1', dummy_lease['start_date'], dummy_lease['end_date'],
-            dummy_lease['project_id'],
-            allow_unreservable=False,
-        )
-        alloc_update.assert_called_once_with(
-            dummy_allocation['id'],
-            {'compute_host_id': new_host['id']})
-        self.assertEqual(True, result)
-
     def test_reallocate_active(self):
         failed_host = {'id': '1',
                        'hypervisor_hostname': 'compute-1'}

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -2252,13 +2252,70 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                                mock.Mock(wraps=datetime.datetime)) as patched:
             patched.utcnow.return_value = datetime.datetime(
                 2020, 1, 1, 11, 00)
-            result = self.fake_phys_plugin._reallocate(dummy_allocation)
+            result = self.fake_phys_plugin._reallocate(dummy_allocation, force=True)
 
         matching_hosts.assert_called_once_with(
             dummy_reservation['hypervisor_properties'],
             dummy_reservation['resource_properties'],
             '1-1', dummy_lease['start_date'], dummy_lease['end_date'],
-            dummy_lease['project_id']
+            dummy_lease['project_id'],
+            allow_unreservable=False,
+        )
+        alloc_update.assert_called_once_with(
+            dummy_allocation['id'],
+            {'compute_host_id': new_host['id']})
+        self.assertEqual(True, result)
+
+    def test_reallocate_before_start_reallocate_to(self):
+        failed_host = {'id': '1'}
+        new_host = {'id': '2'}
+        dummy_allocation = {
+            'id': 'alloc-1',
+            'compute_host_id': failed_host['id'],
+            'reservation_id': 'rsrv-1',
+        }
+        dummy_reservation = {
+            'id': 'rsrv-1',
+            'resource_type': plugin.RESOURCE_TYPE,
+            'lease_id': 'lease-1',
+            'status': 'pending',
+            'hypervisor_properties': [],
+            'resource_properties': [],
+            'resource_id': 'resource-1'
+        }
+        dummy_host_reservation = {
+            'aggregate_id': 1
+        }
+        dummy_lease = {
+            'name': 'lease-name',
+            'start_date': datetime.datetime(2020, 1, 1, 12, 00),
+            'end_date': datetime.datetime(2020, 1, 2, 12, 00),
+            'trust_id': 'trust-1',
+            'project_id': 'fake-project'
+        }
+        reservation_get = self.patch(self.db_api, 'reservation_get')
+        reservation_get.return_value = dummy_reservation
+        host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
+        host_reservation_get.return_value = dummy_host_reservation
+        lease_get = self.patch(self.db_api, 'lease_get')
+        lease_get.return_value = dummy_lease
+        matching_hosts = self.patch(host_plugin.PhysicalHostPlugin,
+                                    '_matching_hosts')
+        matching_hosts.return_value = ["fake_host_id_1", new_host['id'], "fake_host_id_2"]
+        alloc_update = self.patch(self.db_api, 'host_allocation_update')
+
+        with mock.patch.object(datetime, 'datetime',
+                               mock.Mock(wraps=datetime.datetime)) as patched:
+            patched.utcnow.return_value = datetime.datetime(
+                2020, 1, 1, 11, 00)
+            result = self.fake_phys_plugin._reallocate(dummy_allocation, reallocate_to=new_host['id'])
+
+        matching_hosts.assert_called_once_with(
+            dummy_reservation['hypervisor_properties'],
+            dummy_reservation['resource_properties'],
+            '1-1', dummy_lease['start_date'], dummy_lease['end_date'],
+            dummy_lease['project_id'],
+            allow_unreservable=False,
         )
         alloc_update.assert_called_once_with(
             dummy_allocation['id'],
@@ -2312,7 +2369,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             patched.utcnow.return_value = datetime.datetime(
                 2020, 1, 1, 13, 00)
             self.nova_client.client.get.return_value = None, {'servers': []}
-            result = self.fake_phys_plugin._reallocate(dummy_allocation)
+            result = self.fake_phys_plugin._reallocate(dummy_allocation, force=True)
 
         self.remove_compute_host.assert_called_once_with(
             dummy_host_reservation['aggregate_id'],
@@ -2322,7 +2379,8 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             dummy_reservation['resource_properties'],
             '1-1', datetime.datetime(2020, 1, 1, 13, 00),
             dummy_lease['end_date'],
-            'fake-project'
+            'fake-project',
+            allow_unreservable=False,
         )
         alloc_update.assert_called_once_with(
             dummy_allocation['id'],
@@ -2373,16 +2431,71 @@ class PhysicalHostPluginTestCase(tests.TestCase):
                                mock.Mock(wraps=datetime.datetime)) as patched:
             patched.utcnow.return_value = datetime.datetime(
                 2020, 1, 1, 11, 00)
-            result = self.fake_phys_plugin._reallocate(dummy_allocation)
+            result = self.fake_phys_plugin._reallocate(dummy_allocation, force=True)
 
         matching_hosts.assert_called_once_with(
             dummy_reservation['hypervisor_properties'],
             dummy_reservation['resource_properties'],
             '1-1', dummy_lease['start_date'], dummy_lease['end_date'],
-            dummy_lease['project_id']
+            dummy_lease['project_id'],
+            allow_unreservable=False,
         )
         alloc_destroy.assert_called_once_with(dummy_allocation['id'])
         self.assertEqual(False, result)
+
+    def test_reallocate_missing_resources(self):
+        failed_host = {'id': '1'}
+        dummy_allocation = {
+            'id': 'alloc-1',
+            'compute_host_id': failed_host['id'],
+            'reservation_id': 'rsrv-1'
+        }
+        dummy_reservation = {
+            'id': 'rsrv-1',
+            'resource_type': plugin.RESOURCE_TYPE,
+            'lease_id': 'lease-1',
+            'status': 'pending',
+            'hypervisor_properties': [],
+            'resource_properties': [],
+            'resource_id': 'resource-1'
+        }
+        dummy_host_reservation = {
+            'aggregate_id': 1
+        }
+        dummy_lease = {
+            'name': 'lease-name',
+            'start_date': datetime.datetime(2020, 1, 1, 12, 00),
+            'end_date': datetime.datetime(2020, 1, 2, 12, 00),
+            'trust_id': 'trust-1',
+            'project_id': 'fake-project'
+        }
+        reservation_get = self.patch(self.db_api, 'reservation_get')
+        reservation_get.return_value = dummy_reservation
+        host_reservation_get = self.patch(self.db_api, 'host_reservation_get')
+        host_reservation_get.return_value = dummy_host_reservation
+        lease_get = self.patch(self.db_api, 'lease_get')
+        lease_get.return_value = dummy_lease
+        matching_hosts = self.patch(host_plugin.PhysicalHostPlugin,
+                                    '_matching_hosts')
+        matching_hosts.return_value = []
+        alloc_destroy = self.patch(self.db_api, 'host_allocation_destroy')
+
+        with mock.patch.object(datetime, 'datetime',
+                               mock.Mock(wraps=datetime.datetime)) as patched:
+            patched.utcnow.return_value = datetime.datetime(
+                2020, 1, 1, 11, 00)
+            result = self.fake_phys_plugin._reallocate(dummy_allocation, force=False)
+
+        matching_hosts.assert_called_once_with(
+            dummy_reservation['hypervisor_properties'],
+            dummy_reservation['resource_properties'],
+            '1-1', dummy_lease['start_date'], dummy_lease['end_date'],
+            dummy_lease['project_id'],
+            allow_unreservable=False,
+        )
+        alloc_destroy.assert_not_called()
+        self.assertEqual(False, result)
+
 
     def test_matching_hosts_not_allocated_hosts(self):
         def host_allocation_get_all_by_values(**kwargs):

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -2387,7 +2387,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         alloc_destroy.assert_called_once_with(dummy_allocation['id'])
         self.assertEqual(False, result)
 
-    def test_reallocate_missing_resources(self):
+    def test_reallocate_missing_resources_no_force(self):
         failed_host = {'id': '1'}
         dummy_allocation = {
             'id': 'alloc-1',


### PR DESCRIPTION
Host reallocate could ruin a reservation if no other hosts were found, and it could reallocate to a reserved host.

The first issue is fixed by only deallocating on success, or when the user specifies `force`.

The second issue is fixed by never reallocating to an unreservable host, since this behavior is never desired.

See client update https://github.com/ChameleonCloud/blazar/pull/127
