### PR TITLE
Add additional invalid ironic provision states to monitor

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -1003,8 +1003,11 @@ class PhysicalHostMonitorPlugin(monitor.GeneralMonitorPlugin,
         try:
             if ironic_hosts:
                 invalid_power_states = ['error']
-                invalid_provision_states = ['error', 'clean failed',
-                                            'manageable', 'deploy failed']
+                invalid_provision_states = [
+                    'error', 'clean failed', 'manageable', 'deploy failed',
+                    'inspect failed', 'clean failed', 'adopt failed',
+                    'rescue failed', 'unrescue failed', 'enroll',
+                ]
                 reservable_hosts = [h for h in ironic_hosts
                                     if h['reservable'] is True]
                 unreservable_hosts = [h for h in ironic_hosts


### PR DESCRIPTION
Adds terminal and admin-only ironic provision states to the host monitor. This will prevent users from making reservations for hosts in these states. Transitory states are not included in this list for the sake of brevity, only states that require an operator to intervene.

For reference:
https://docs.openstack.org/ironic/latest/user/states.html

Change-Id: Ia04a360bdb7aabadd70afa9da682f08190f53bd8