### PR TITLE
Fix logging for tests

### DIFF
--- a/blazar/api/v1/utils.py
+++ b/blazar/api/v1/utils.py
@@ -296,11 +296,11 @@ def get_request_args():
 
 def abort_and_log(status_code, descr, exc=None):
     """Process occurred errors."""
-    LOG.error("Request aborted with status code %(code)s and "
+    LOG.warning("Request aborted with status code %(code)s and "
               "message '%(msg)s'", {'code': status_code, 'msg': descr})
 
     if exc is not None:
-        LOG.error(traceback.format_exc())
+        LOG.warning(traceback.format_exc())
 
     flask.abort(status_code, description=descr)
 

--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -392,7 +392,7 @@ class ManagerService(service_utils.RPCServer):
                     self._check_date_within_lease_limits(before_end_date,
                                                          lease_values)
                 except common_ex.BlazarException as e:
-                    LOG.error("Invalid before_end_date param. %s", str(e))
+                    LOG.warning("Invalid before_end_date param. %s", str(e))
                     raise e
             elif CONF.manager.minutes_before_end_lease > 0:
                 delta = datetime.timedelta(
@@ -437,7 +437,7 @@ class ManagerService(service_utils.RPCServer):
                     self.enforcement.check_create(
                         context.current(), lease_values, reservations, allocations)
                 except common_ex.NotAuthorized as e:
-                    LOG.error("Enforcement checks failed. %s", str(e))
+                    LOG.warning("Enforcement checks failed. %s", str(e))
                     db_api.lease_destroy(lease_id)
                     raise common_ex.NotAuthorized(e)
 
@@ -520,7 +520,7 @@ class ManagerService(service_utils.RPCServer):
                 self._check_date_within_lease_limits(before_end_date,
                                                      values)
             except common_ex.BlazarException as e:
-                LOG.error("Invalid before_end_date param. %s", str(e))
+                LOG.warning("Invalid before_end_date param. %s", str(e))
                 raise e
 
         # TODO(frossigneux) rollback if an exception is raised

--- a/blazar/tests/api/__init__.py
+++ b/blazar/tests/api/__init__.py
@@ -15,6 +15,7 @@
 
 """Base classes for API tests."""
 from keystonemiddleware import fixture
+from oslo_log import log as logging
 from oslo_utils import uuidutils
 import pecan
 import pecan.testing
@@ -24,6 +25,8 @@ from blazar import context
 from blazar.manager.leases import rpcapi as leases_api
 from blazar.manager.oshosts import rpcapi as hosts_rpcapi
 from blazar import tests
+
+LOG = logging.getLogger(__name__)
 
 PATH_PREFIX = '/v2'
 
@@ -127,7 +130,7 @@ class APITest(tests.TestCase):
         :param path_prefix: prefix of the url path
         """
         full_path = path_prefix + path
-        print('%s: %s %s' % (method.upper(), full_path, params))
+        LOG.debug('%s: %s %s' % (method.upper(), full_path, params))
         response = getattr(self.app, "%s_json" % method)(
             str(full_path),
             params=params,
@@ -136,7 +139,7 @@ class APITest(tests.TestCase):
             extra_environ=extra_environ,
             expect_errors=expect_errors
         )
-        print('GOT:%s' % response)
+        LOG.debug('GOT:%s' % response)
         return response
 
     def put_json(self, path, params, expect_errors=False, headers=None,
@@ -189,13 +192,13 @@ class APITest(tests.TestCase):
         :param path_prefix: prefix of the url path
         """
         full_path = path_prefix + path
-        print('DELETE: %s' % (full_path))
+        LOG.debug('DELETE: %s' % (full_path))
         response = self.app.delete(str(full_path),
                                    headers=headers,
                                    status=status,
                                    extra_environ=extra_environ,
                                    expect_errors=expect_errors)
-        print('GOT:%s' % response)
+        LOG.debug('GOT:%s' % response)
         return response
 
     def get_json(self, path, expect_errors=False, headers=None,
@@ -225,7 +228,7 @@ class APITest(tests.TestCase):
         all_params.update(params)
         if q:
             all_params.update(query_params)
-        print('GET: %s %r' % (full_path, all_params))
+        LOG.debug('GET: %s %r' % (full_path, all_params))
         response = self.app.get(full_path,
                                 params=all_params,
                                 headers=headers,
@@ -233,5 +236,5 @@ class APITest(tests.TestCase):
                                 expect_errors=expect_errors)
         if not expect_errors:
             response = response.json
-        print('GOT:%s' % response)
+        LOG.debug('GOT:%s' % response)
         return response

--- a/blazar/tests/api/test_context.py
+++ b/blazar/tests/api/test_context.py
@@ -45,7 +45,7 @@ class ContextTestCase(tests.TestCase):
             self.fake_headers)
 
     def test_ctx_from_headers_wrong_format(self):
-        catalog = '["etc"]'
+        catalog = ['etc']
         self.fake_headers['X-Service-Catalog'] = catalog
         self.assertRaises(
             exceptions.WrongFormat,

--- a/blazar/tests/api/test_context.py
+++ b/blazar/tests/api/test_context.py
@@ -45,7 +45,7 @@ class ContextTestCase(tests.TestCase):
             self.fake_headers)
 
     def test_ctx_from_headers_wrong_format(self):
-        catalog = ['etc']
+        catalog = '["etc"]'
         self.fake_headers['X-Service-Catalog'] = catalog
         self.assertRaises(
             exceptions.WrongFormat,

--- a/blazar/tests/api/v1/test_validation.py
+++ b/blazar/tests/api/v1/test_validation.py
@@ -44,7 +44,7 @@ class ValidationTestCase(tests.TestCase):
 
     def test_check_false(self):
         fake_get = self.patch(
-            self.s_api.API, 'get_lease').side_effect = self.exc.NotFound()
+            self.s_api.API, 'get_lease').side_effect = self.exc.NotFound(message="test message")
 
         @self.v_api.check_exists(fake_get, self.fake_id)
         def trap(fake_id):

--- a/blazar/tests/manager/test_service.py
+++ b/blazar/tests/manager/test_service.py
@@ -1599,7 +1599,7 @@ class ServiceTestCase(tests.DBTestCase):
         self.event_update.assert_called_once_with('1', {'status': 'DONE'})
 
     def test_basic_action_raise_exception(self):
-        def raiseBlazarException(resource_id):
+        def raiseBlazarException(resource_id, lease):
             raise exceptions.BlazarException(resource_id)
 
         self.manager.resource_actions = (
@@ -1619,7 +1619,7 @@ class ServiceTestCase(tests.DBTestCase):
         self.event_update.assert_called_once_with('1', {'status': 'ERROR'})
 
     def test_basic_action_raise_exception_no_reservation_status(self):
-        def raiseBlazarException(resource_id):
+        def raiseBlazarException(resource_id, lease):
             raise exceptions.BlazarException(resource_id)
 
         self.manager.resource_actions = (


### PR DESCRIPTION
Replaces non error logs with warning. Replaces a lot of `print` with `log.debug`. Also fixes a few tests that logged exceptions. There are a lot of these type of errors unfortunately, and its difficult to tell which are expected, but this is at least a small dent.