### PR TITLE
Fix 500 error when updating network/device capabilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
             --system \
             -r requirements.txt \
             -r test-requirements.txt \
+            -c https://releases.openstack.org/constraints/upper/2023.1 \
             .
       - name: init stestr repo
         run: stestr init

--- a/blazar/db/sqlalchemy/utils.py
+++ b/blazar/db/sqlalchemy/utils.py
@@ -22,6 +22,8 @@ from blazar.db.sqlalchemy import models
 from blazar.manager import exceptions as mgr_exceptions
 from blazar.plugins import instances as instance_plugin
 from blazar.plugins import oshosts as host_plugin
+from blazar.plugins import devices as device_plugin
+from blazar.plugins import networks as network_plugin
 from blazar import status
 from collections import defaultdict
 import sqlalchemy as sa
@@ -447,6 +449,10 @@ def get_plugin_reservation(resource_type, resource_id):
         return api.host_reservation_get(resource_id)
     elif resource_type == instance_plugin.RESOURCE_TYPE:
         return api.instance_reservation_get(resource_id)
+    elif resource_type == network_plugin.RESOURCE_TYPE:
+        return api.network_reservation_get(resource_id)
+    elif resource_type == device_plugin.RESOURCE_TYPE:
+        return api.device_reservation_get(resource_id)
     else:
         raise mgr_exceptions.UnsupportedResourceType(
             resource_type=resource_type)

--- a/blazar/tests/db/sqlalchemy/test_utils.py
+++ b/blazar/tests/db/sqlalchemy/test_utils.py
@@ -350,6 +350,26 @@ class SQLAlchemyDBUtilsTestCase(tests.DBTestCase):
         db_utils.get_plugin_reservation('virtual:instance', 'id-1')
         patch_inst_reservation_get.assert_called_once_with('id-1')
 
+    def test_get_plugin_reservation_with_device(self):
+        patch_dev_reservation_get = self.patch(db_api,
+                                                'device_reservation_get')
+        patch_dev_reservation_get.return_value = {
+            'id': 'id',
+            'reservation_id': 'reservation-id',
+        }
+        db_utils.get_plugin_reservation('device', 'id-1')
+        patch_dev_reservation_get.assert_called_once_with('id-1')
+
+    def test_get_plugin_reservation_with_network(self):
+        patch_net_reservation_get = self.patch(db_api,
+                                                'network_reservation_get')
+        patch_net_reservation_get.return_value = {
+            'id': 'id',
+            'reservation_id': 'reservation-id',
+        }
+        db_utils.get_plugin_reservation('network', 'id-1')
+        patch_net_reservation_get.assert_called_once_with('id-1')
+
     def test_get_plugin_reservation_with_invalid(self):
         self.assertRaises(mgr_exceptions.UnsupportedResourceType,
                           db_utils.get_plugin_reservation, 'invalid', 'id1')


### PR DESCRIPTION
Fix the 500 error that happens if you try to update a network or device property when there are active reservations on it. This extra logic is to prevent interfering with property that is used by an active reservation, but was never added for device/network.

This also adds upper constraints to the GHA workflow, needed for the DB setup which will be updated in later OS versions.