### PR TITLE
Add usage reporting CLI

### DIFF
--- a/blazar/cmd/usage.py
+++ b/blazar/cmd/usage.py
@@ -7,7 +7,7 @@ CONF = cfg.CONF
 
 
 def list_leases(args):
-    print("start,end,hours_before_start,number_of_hosts,numer_of_networks,id,project_id,host_id,hypervisor_hostname,node_name,node_type")
+    print("start,end,created_at,hours_before_start,number_of_hosts,numer_of_networks,id,user_id,project_id,host_id,hypervisor_hostname,node_name,node_type")
     since_datetime = None
     if args.since:
         since_datetime = datetime.strptime(args.since, "%Y-%m-%d %H:%M")
@@ -41,10 +41,12 @@ def list_leases(args):
                 print(
                     lease["start_date"],
                     lease["end_date"],
+                    lease["created_at"],
                     td,
                     len(db_api.hosts_in_lease(lease["id"])),
                     len(db_api.networks_in_lease(lease["id"])),
                     lease["id"],
+                    lease["user_id"],
                     lease["project_id"],
                     host["id"],
                     host["hypervisor_hostname"],

--- a/blazar/cmd/usage.py
+++ b/blazar/cmd/usage.py
@@ -1,0 +1,49 @@
+import sys
+from oslo_config import cfg
+from blazar.db import api as db_api
+from datetime import datetime
+
+CONF = cfg.CONF
+
+
+def list_leases(args):
+    print("hours_before_start,number_of_hosts,numer_of_networks,id")
+    for lease in db_api.lease_list():
+        created_at = datetime.strptime(lease["created_at"], "%Y-%m-%d %H:%M:%S")
+        td = max(0, (lease["start_date"] - created_at).total_seconds())/3600
+        print(
+            td,
+            len(db_api.hosts_in_lease(lease["id"])),
+            len(db_api.networks_in_lease(lease["id"])),
+            lease["id"], 
+            sep=",",
+        )
+    
+
+def add_command_parsers(subparsers):
+    parser = subparsers.add_parser('list_leases')
+    parser.set_defaults(func=list_leases)
+
+
+command_opts = [
+    cfg.SubCommandOpt('command',
+                      title='Command',
+                      help='Available commands',
+                      handler=add_command_parsers)
+]
+CONF.register_cli_opts(command_opts)
+
+
+def main():
+    CONF(project='blazar', prog='blazar-manager')
+    CONF.set_override("include_deleted", True)
+
+    if hasattr(CONF.command, 'func'):
+        CONF.command.func(CONF.command)
+    else:
+        print("No valid command specified.")
+        CONF.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/blazar/cmd/usage.py
+++ b/blazar/cmd/usage.py
@@ -7,21 +7,64 @@ CONF = cfg.CONF
 
 
 def list_leases(args):
-    print("hours_before_start,number_of_hosts,numer_of_networks,id")
+    print("start,end,hours_before_start,number_of_hosts,numer_of_networks,id,project_id,host_id,hypervisor_hostname,node_name,node_type")
+    since_datetime = None
+    if args.since:
+        since_datetime = datetime.strptime(args.since, "%Y-%m-%d %H:%M")
+    hosts_by_id = {}
     for lease in db_api.lease_list():
-        created_at = datetime.strptime(lease["created_at"], "%Y-%m-%d %H:%M:%S")
-        td = max(0, (lease["start_date"] - created_at).total_seconds())/3600
-        print(
-            td,
-            len(db_api.hosts_in_lease(lease["id"])),
-            len(db_api.networks_in_lease(lease["id"])),
-            lease["id"], 
-            sep=",",
-        )
-    
+        try:
+            if since_datetime and lease["start_date"] < since_datetime:
+                continue
+
+            created_at = datetime.strptime(lease["created_at"], "%Y-%m-%d %H:%M:%S")
+            td = max(0, (lease["start_date"] - created_at).total_seconds())/3600
+            all_allocations = []
+            for allocations in [
+                db_api.host_allocation_get_all_by_values(reservation_id=x['id'])
+                for x in lease["reservations"]
+                if x["resource_type"] in ["physical:host", "flavor:instance"]
+            ]:
+                all_allocations.extend(
+                    hosts_by_id.setdefault(
+                        a["compute_host_id"],
+                        db_api.host_get(a["compute_host_id"])
+                    )
+                    for a in allocations
+                )
+            for host in all_allocations:
+                if not host.get("extras"):
+                    host["extras"] = {
+                        k: v.capability_value
+                        for v, k in db_api.host_extra_capability_get_all_per_host(host["id"])
+                    }
+                print(
+                    lease["start_date"],
+                    lease["end_date"],
+                    td,
+                    len(db_api.hosts_in_lease(lease["id"])),
+                    len(db_api.networks_in_lease(lease["id"])),
+                    lease["id"],
+                    lease["project_id"],
+                    host["id"],
+                    host["hypervisor_hostname"],
+                    host["extras"]["node_name"],
+                    host["extras"]["node_type"],
+                    sep=",",
+                )
+        except Exception as e:
+            print(f"Error processing lease {lease['id']}: {e}", file=sys.stderr)
+            continue
+    print(args)
+
 
 def add_command_parsers(subparsers):
     parser = subparsers.add_parser('list_leases')
+    parser.add_argument(
+        '--since',
+        type=str,
+        help='Start date for filtering leases (YYYY-MM-DD HH:MM format)'
+    )
     parser.set_defaults(func=list_leases)
 
 

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -43,7 +43,7 @@ FORBIDDEN_RESOURCE_PROPERTY_NAMES = ["id", "reservable"]
 LOG = logging.getLogger(__name__)
 
 get_engine = facade_wrapper.get_engine
-# Add a new configuration option
+
 cfg.CONF.register_opt(cfg.BoolOpt(
     'include_deleted', default=False, help='Include deleted in queries (used by scripts)'))
 

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -28,8 +28,6 @@ from oslo_log import log as logging
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import asc
 from sqlalchemy.sql.expression import desc
-from blazar.db.sqlalchemy import facade_wrapper
-from oslo_config import cfg
 
 
 RESOURCE_PROPERTY_MODELS = {

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -28,6 +28,8 @@ from oslo_log import log as logging
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import asc
 from sqlalchemy.sql.expression import desc
+from blazar.db.sqlalchemy import facade_wrapper
+from oslo_config import cfg
 
 
 RESOURCE_PROPERTY_MODELS = {
@@ -41,8 +43,11 @@ FORBIDDEN_RESOURCE_PROPERTY_NAMES = ["id", "reservable"]
 LOG = logging.getLogger(__name__)
 
 get_engine = facade_wrapper.get_engine
-get_session = facade_wrapper.get_session
+# Add a new configuration option
+cfg.CONF.register_opt(cfg.BoolOpt(
+    'include_deleted', default=False, help='Include deleted in queries (used by scripts)'))
 
+get_session = facade_wrapper.get_session
 
 def get_backend():
     """The backend is this module itself."""
@@ -54,7 +59,7 @@ def _read_deleted_filter(query, db_model, deleted):
         return query
 
     default_deleted_value = None
-    if not deleted:
+    if not deleted and not cfg.CONF.include_deleted:
         query = query.filter(db_model.deleted == default_deleted_value)
     return query
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ console_scripts =
     blazar-rpc-zmq-receiver=blazar.cmd.rpc_zmq_receiver:main
     blazar-manager=blazar.cmd.manager:main
     blazar-status=blazar.cmd.status:main
+    blazar-usage=blazar.cmd.usage:main
 
 blazar.resource.plugins =
     device.plugin=blazar.plugins.devices.device_plugin:DevicePlugin


### PR DESCRIPTION
Adds a usage reporting CLI tool we can use to export blazar data. Right now this prints CSV output a line for each host allocation in a lease information about that lease and host. Here is a sample:

```
start,end,created_at,hours_before_start,number_of_hosts,numer_of_networks,id,user_id,project_id,host_id,hypervisor_hostname,node_name,node_type
2025-02-26 21:12:00,2025-02-27 21:11:00,2025-02-26 21:11:49,0.0030555555555555557,1,0,0e5edd08-1edc-4162-911e-caf3825d6820,c908862cf9754d3083bd2deb67ecdcb5,3bae9ac771d7422c8915e0ab0c93d23b,f89298e0-e80c-4c2e-aafd-97345bdcef12,mark-devstack_1,md1,gpu_h100
2025-03-06 17:21:00,2025-03-07 17:37:00,2025-03-04 17:37:31,47.72472222222222,1,0,eda9e62e-a30f-4db7-94b7-a993a44a13c8,c908862cf9754d3083bd2deb67ecdcb5,3bae9ac771d7422c8915e0ab0c93d23b,f89298e0-e80c-4c2e-aafd-97345bdcef12,mark-devstack_1,md1,gpu_h100
```