### PR TITLE
Backport policy fix to properly enforce lease ownership

### DIFF
--- a/blazar/policy.py
+++ b/blazar/policy.py
@@ -25,6 +25,7 @@ from oslo_policy import policy
 from blazar import context
 from blazar import exceptions
 from blazar import policies
+from blazar.db import api as db_api
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
@@ -134,7 +135,19 @@ def authorize(extension, action=None, api='blazar', ctx=None,
     def decorator(func):
         @functools.wraps(func)
         def wrapped(self, *args, **kwargs):
-            check_enforcement(extension, action, api, ctx, target)
+            new_target = target
+            if new_target is None:
+                obj = None
+                if kwargs.get("lease_id"):
+                    obj = db_api.lease_get(kwargs.get("lease_id"))
+                if obj:
+                    new_target = {
+                        'project': obj.get("project_id"),
+                        'user': obj.get("user_id"),
+                        'project_id': obj.get("project_id"),
+                        'user_id': obj.get("user_id"),
+                    }
+            check_enforcement(extension, action, api, ctx, new_target)
             return func(self, *args, **kwargs)
 
         return wrapped


### PR DESCRIPTION
Fix owner policy enforcement
Previously, target was always None, and so ownership check essentially
compared the current context against itself. Under this implementation,
if the target is None, we look up the relevant object based on kwargs,
and then use this object as the target.

At the moment "lease" is the only type of object that has ownership,
and so it is the only case.

---

See upstream commit https://github.com/openstack/blazar/commit/e407e8da0225e319807e96bf709720b0ee2257fb

Will backport to KVM after this merge

Change-Id: Id93766acaca4f66667897199a3c86c38213d1996