### PR TITLE
refactor usage of placement API in flavor plugin

### DIFF
--- a/blazar/plugins/flavor/flavor_plugin.py
+++ b/blazar/plugins/flavor/flavor_plugin.py
@@ -131,8 +131,12 @@ class FlavorPlugin(base.BasePlugin):
         except ValueError as e:
             raise mgr_exceptions.MalformedParameter(str(e))
 
-    def _query_available_hosts(self, start_date, end_date,
-                               resource_request, resource_traits, excludes=[]):
+    def _annotate_hosts_with_reservations(self, start_date, end_date, excludes):
+        """
+        Return a list of dicts, each one with structure:
+        {'host': host, 'reservations': reservations}
+        """
+
         # TODO(johngarbutt): offload more of this to the db
         # we should be able to exclude hosts that don't match the
         # resource requests, e.g. baremetal vs virtual
@@ -147,39 +151,52 @@ class FlavorPlugin(base.BasePlugin):
                 start_date - datetime.timedelta(minutes=CONF.cleaning_time),
                 end_date + datetime.timedelta(minutes=CONF.cleaning_time),
                 excludes)
+        
+        return [free_hosts + reserved_hosts]
+    
+    
+    def _get_placement_rps(self, resource_traits):
+        """
+        format the traits list into a string consumable by placement API
+        query for all RPs matching the needed traits, and return that list
+        """
 
-        def _get_rp_traits(rp):
-            return rp, self._placement_client.get_traits(rp["uuid"])
+        traits_list = []
+        for trait, value in resource_traits.items():
+            if value == "required":
+                traits_list.append(trait)
+            elif value == "forbidden":
+                # prefix forbidden traits with `!`
+                traits_list.append(f"!{trait})")
+            else:
+                raise ValueError("invalid trait request for %s:%s", trait, value)
+        
+        required_string = ",".join(traits_list)
 
-        # Gather hosts per resource trait
-        hosts_by_trait = collections.defaultdict(set)
-        resource_providers = self._placement_client.list_resource_providers()
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = [
-                executor.submit(_get_rp_traits, rp)
-                for rp in resource_providers
-            ]
+        placement_rps_matching_traits = self._placement_client.list_resource_providers_query(
+            f"required={required_string}", 
+            microversion="1.22",
+        )
+        return placement_rps_matching_traits
 
-            for future in concurrent.futures.as_completed(futures):
-                rp, traits = future.result()
-                for trait in traits:
-                    hosts_by_trait[trait].add(rp["name"])
+    def _query_available_hosts(self, start_date, end_date,
+                               resource_request, resource_traits, excludes=[]):
+        
+        blazar_hosts_with_res = self._annotate_hosts_with_reservations(
+            start_date, 
+            end_date, 
+            excludes,
+        )
+
+        placement_rps_matching_traits = self._get_placement_rps(
+            resource_traits=resource_traits
+        )
+
         available_hosts = []
-        for host_info in (reserved_hosts + free_hosts):
-            # First check placement traits
-            hostname = host_info['host']['hypervisor_hostname']
-            host_passes_trait_check = True
-            for trait, value in resource_traits.items():
-                matching_hosts = hosts_by_trait.get(trait, [])
-                if (
-                    (value == "required" and hostname not in matching_hosts) or
-                    (value == "forbidden" and hostname in matching_hosts)
-                ):
-                    LOG.debug(f"Host {hostname} fails trait condition for trait {trait}")
-                    host_passes_trait_check = False
-                    break
-            if not host_passes_trait_check:
-                # Host cannot be considered available for this reservation
+        for host_info in blazar_hosts_with_res:
+            hypervisor_hostname = host_info['host']['hypervisor_hostname']
+            if hypervisor_hostname not in placement_rps_matching_traits:
+                LOG.debug("Placement filtered out host %s", hypervisor_hostname)
                 continue
 
             # check how many instances can fit on this host

--- a/blazar/utils/openstack/placement.py
+++ b/blazar/utils/openstack/placement.py
@@ -710,6 +710,18 @@ class BlazarPlacementClient(object):
             if json_resp['resource_providers']:
                 resource_providers = json_resp['resource_providers']
         return resource_providers
+    
+    def list_resource_providers_query(self, params_string, microversion):
+        """Get all resource providers."""
+
+        url = f"/resource_providers?{params_string}"
+        resp = self.get(url, microversion=microversion)
+        resource_providers = []
+        if resp:
+            json_resp = resp.json()
+            if json_resp['resource_providers']:
+                resource_providers = json_resp['resource_providers']
+        return resource_providers
 
     def get_trait_resource_providers(self, trait_name):
         """Get all resource providers that associate with the trait


### PR DESCRIPTION
Instead of querying placment for all traits for all blazar hosts, instead ask placement for a list of RPs matching the traits we want. This should go from len(traits) * len(hosts) to 1 query.

Also include a hacky example of how to modify blazar placement client we must query placement API with params, and current placementclient does not implement that.

Need to verify that `if hypervisor_hostname not in placement_rps_matching_traits` is the correct query for matching.

This also assumes that traits are not findable via `db_api.reservable_host_get_all_by_queries([])`, e.g. placement traits are not mirrored into blazar.

Also of note: the response from placement may includes RPs that are not hosts, e.g. placement resources for reservations and GPUs. This is still ok, as the hypervisor hostname won't match the uuid of those RPs, but they could be excluded by requiring trait `COMPUTE_NODE`, for example