### PR TITLE
Sum resource inventory for a host across child RPs

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -439,8 +439,32 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         if rp is None:
             raise manager_ex.ResourceProviderNotFound(host=hostname)
 
-        inventories = self.placement_client.get_inventory(rp['uuid'])
-        for rc, inventory in inventories['inventories'].items():
+        tree_rps = self.placement_client.list_resource_providers(
+            query="in_tree=%s" % rp['uuid'])
+
+        aggregated_inventories = {}
+        for tree_rp in tree_rps:
+            inventories = self.placement_client.get_inventory(tree_rp['uuid'])
+            for rc, inventory in inventories['inventories'].items():
+                if rc not in aggregated_inventories:
+                    aggregated_inventories[rc] = {
+                        'total': 0,
+                        'reserved': 0,
+                        'min_unit': inventory['min_unit'],
+                        'max_unit': inventory['max_unit'],
+                        'step_size': inventory['step_size'],
+                        'allocation_ratio': inventory['allocation_ratio'],
+                    }
+                else:
+                    aggregated_inventories[rc]['max_unit'] = max(
+                        aggregated_inventories[rc]['max_unit'],
+                        inventory['max_unit']
+                    )
+
+                aggregated_inventories[rc]['total'] += inventory['total']
+                aggregated_inventories[rc]['reserved'] += inventory['reserved']
+
+        for rc, inventory in aggregated_inventories.items():
             resource_inventory = {
                 'computehost_id': host['id'],
                 'resource_class': rc,

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -445,9 +445,9 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         aggregated_inventories = {}
         for tree_rp in tree_rps:
             inventories = self.placement_client.get_inventory(tree_rp['uuid'])
-            for rc, inventory in inventories['inventories'].items():
-                if rc not in aggregated_inventories:
-                    aggregated_inventories[rc] = {
+            for resource_class, inventory in inventories['inventories'].items():
+                if resource_class not in aggregated_inventories:
+                    aggregated_inventories[resource_class] = {
                         'total': 0,
                         'reserved': 0,
                         'min_unit': inventory['min_unit'],
@@ -456,13 +456,17 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                         'allocation_ratio': inventory['allocation_ratio'],
                     }
                 else:
-                    aggregated_inventories[rc]['max_unit'] = max(
-                        aggregated_inventories[rc]['max_unit'],
+                    m = max(
+                        aggregated_inventories[resource_class]['max_unit'],
                         inventory['max_unit']
                     )
+                    if aggregated_inventories[resource_class]['max_unit'] != inventory['max_unit']:
+                        LOG.warning("Different max_units for resource %s on host %s, using max value %s",
+                                    resource_class, hostname, m)
+                    aggregated_inventories[resource_class]['max_unit'] = m
 
-                aggregated_inventories[rc]['total'] += inventory['total']
-                aggregated_inventories[rc]['reserved'] += inventory['reserved']
+                aggregated_inventories[resource_class]['total'] += inventory['total']
+                aggregated_inventories[resource_class]['reserved'] += inventory['reserved']
 
         for rc, inventory in aggregated_inventories.items():
             resource_inventory = {

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -210,13 +210,15 @@ class PhysicalHostPluginTestCase(tests.TestCase):
     @mock.patch.object(db_api, 'host_resource_inventory_create')
     @mock.patch.object(placement.BlazarPlacementClient, 'get_traits')
     @mock.patch.object(placement.BlazarPlacementClient, 'get_inventory')
+    @mock.patch.object(placement.BlazarPlacementClient, 'list_resource_providers')
     @mock.patch.object(placement.BlazarPlacementClient,
                        'get_resource_provider')
     def test_create_host_without_extra_capabilities(
-            self, mock_get_rp, mock_get_inventory, mock_get_traits,
+            self, mock_get_rp, mock_list_rp, mock_get_inventory, mock_get_traits,
             mock_db_inv, mock_db_trait):
 
         mock_get_rp.return_value = {"uuid": "fake_rp_uuid"}
+        mock_list_rp.return_value = [{"uuid": "fake_rp_uuid"}]
         mock_get_traits.return_value = ["CUSTOM_HW_FPGA_CLASS1"]
         mock_get_inventory.return_value = {
             "inventories": {
@@ -250,6 +252,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         fake_db_return.pop("id")
         self.db_host_create.assert_called_once_with(fake_db_return)
         self.prov_create.assert_called_once_with('hypvsr1')
+        mock_list_rp.assert_called_once_with(query="in_tree=fake_rp_uuid")
         mock_get_inventory.assert_called_once_with("fake_rp_uuid")
         mock_get_traits.assert_called_once_with("fake_rp_uuid")
         mock_db_trait.assert_called_once_with({
@@ -271,13 +274,15 @@ class PhysicalHostPluginTestCase(tests.TestCase):
     @mock.patch.object(db_api, 'host_resource_inventory_create')
     @mock.patch.object(placement.BlazarPlacementClient, 'get_traits')
     @mock.patch.object(placement.BlazarPlacementClient, 'get_inventory')
+    @mock.patch.object(placement.BlazarPlacementClient, 'list_resource_providers')
     @mock.patch.object(placement.BlazarPlacementClient,
                        'get_resource_provider')
     def test_create_host_with_extra_capabilities(
-            self, mock_get_rp, mock_get_inventory, mock_get_traits,
+            self, mock_get_rp, mock_list_rp, mock_get_inventory, mock_get_traits,
             mock_db_inv, mock_db_trait):
 
         mock_get_rp.return_value = {"uuid": "fake_rp_uuid"}
+        mock_list_rp.return_value = [{"uuid": "fake_rp_uuid"}]
         mock_get_traits.return_value = []
         mock_get_inventory.return_value = {
             "inventories": {
@@ -313,6 +318,7 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         self.db_host_extra_capability_create.assert_called_once_with(fake_capa)
         # the returned host will not have id
         self.assertEqual(fake_host, host)
+        mock_list_rp.assert_called_once_with(query="in_tree=fake_rp_uuid")
         mock_get_inventory.assert_called_once_with("fake_rp_uuid")
         mock_get_traits.assert_called_once_with("fake_rp_uuid")
         mock_db_trait.assert_not_called()
@@ -326,6 +332,113 @@ class PhysicalHostPluginTestCase(tests.TestCase):
             "reserved": 512,
             "total": 5825
         })
+
+    @mock.patch.object(db_api, 'host_trait_create')
+    @mock.patch.object(db_api, 'host_resource_inventory_create')
+    @mock.patch.object(placement.BlazarPlacementClient, 'get_traits')
+    @mock.patch.object(placement.BlazarPlacementClient, 'get_inventory')
+    @mock.patch.object(placement.BlazarPlacementClient, 'list_resource_providers')
+    @mock.patch.object(placement.BlazarPlacementClient,
+                       'get_resource_provider')
+    def test_create_host_with_child_resource_providers(
+            self, mock_get_rp, mock_list_rp, mock_get_inventory, mock_get_traits,
+            mock_db_inv, mock_db_trait):
+
+        mock_get_rp.return_value = {"uuid": "fake_rp_uuid"}
+        mock_list_rp.return_value = [{"uuid": "fake_rp_uuid"}, {"uuid": "fake_child_rp_uuid"}]
+
+        def fake_get_traits(rp_uuid):
+            if rp_uuid == "fake_rp_uuid":
+                return ["CUSTOM_PARENT_TRAIT"]
+            else:
+                return ["CUSTOM_CHILD_TRAIT"]
+        mock_get_traits.side_effect = fake_get_traits
+
+        def fake_get_inventory(rp_uuid):
+            if rp_uuid == "fake_rp_uuid":
+                return {
+                    "inventories": {
+                        "MEMORY_MB": {
+                            "allocation_ratio": 1.5,
+                            "max_unit": 5825,
+                            "min_unit": 1,
+                            "reserved": 512,
+                            "step_size": 1,
+                            "total": 5825
+                        },
+                        "CUSTOM_RESOURCE": {
+                            "allocation_ratio": 1.0,
+                            "max_unit": 10,
+                            "min_unit": 1,
+                            "reserved": 2,
+                            "step_size": 1,
+                            "total": 10
+                        }
+                    },
+                    "resource_provider_generation": 7
+                }
+            else:
+                return {
+                    "inventories": {
+                        "CUSTOM_RESOURCE": {
+                            "allocation_ratio": 1.0,
+                            "max_unit": 5,
+                            "min_unit": 1,
+                            "reserved": 1,
+                            "step_size": 1,
+                            "total": 20
+                        }
+                    },
+                    "resource_provider_generation": 2
+                }
+        mock_get_inventory.side_effect = fake_get_inventory
+
+        fake_host = self.fake_host.copy()
+        fake_request = fake_host.copy()
+        self.get_extra_capabilities.return_value = {}
+        self.db_host_create.return_value = fake_host
+
+        host = self.fake_phys_plugin.create_computehost(fake_request)
+
+        expected_fake_host = self.fake_host.copy()
+        expected_fake_host.pop("id")
+        self.db_host_create.assert_called_once_with(expected_fake_host)
+
+        mock_list_rp.assert_called_once_with(query="in_tree=fake_rp_uuid")
+
+        expected_traits = [
+            mock.call({
+                'computehost_id': '1',
+                'trait': "CUSTOM_PARENT_TRAIT",
+            })
+        ]
+        mock_db_trait.assert_has_calls(expected_traits, any_order=True)
+
+        expected_inv = [
+            mock.call({
+                'computehost_id': '1',
+                'resource_class': "MEMORY_MB",
+                "allocation_ratio": 1.5,
+                "max_unit": 5825,
+                "min_unit": 1,
+                "step_size": 1,
+                "reserved": 512,
+                "total": 5825
+            }),
+            mock.call({
+                'computehost_id': '1',
+                'resource_class': "CUSTOM_RESOURCE",
+                "allocation_ratio": 1.0,
+                "max_unit": 10,
+                "min_unit": 1,
+                "step_size": 1,
+                "reserved": 3,
+                "total": 30
+            })
+        ]
+        mock_db_inv.assert_has_calls(expected_inv, any_order=True)
+
+
 
     def test_create_host_with_capabilities_too_long(self):
         fake_host = self.fake_host.copy()


### PR DESCRIPTION
The previous implementation only looked at the top level RP when storing the resource inventory. This is an issue since VGPUs are set on child resource providers.

This change sums the total resources for each host across all RPs in the tree, starting with the host's resource provider. Currently, we must reenroll a host in blazar to update the inventory, but in the future we could do some sort of sync in the monitor.