### PR TITLE
fix "list_computehosts" slowness

### DIFF
--- a/blazar/db/api.py
+++ b/blazar/db/api.py
@@ -431,6 +431,11 @@ def host_extra_capability_get_all_per_host(host_id):
     return IMPL.host_extra_capability_get_all_per_host(host_id)
 
 
+def host_extra_capability_get_all_per_hosts(host_ids):
+    """Return all extra_capabilities for a list of Compute hosts."""
+    return IMPL.host_extra_capability_get_all_per_hosts(host_ids)
+
+
 def host_extra_capability_destroy(host_extra_capability_id):
     """Delete specific host ExtraCapability."""
     IMPL.host_extra_capability_destroy(host_extra_capability_id)

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -933,6 +933,12 @@ def host_extra_capability_get_all_per_host(host_id):
                                                    host_id).all()
 
 
+def host_extra_capability_get_all_per_hosts(host_ids):
+    query = _host_resource_property_query(get_session()).filter(
+        models.ComputeHostExtraCapability.computehost_id.in_(host_ids))
+    return query.all()
+
+
 def host_extra_capability_create(values):
     values = values.copy()
 

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -314,6 +314,14 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
                      '(lease: %s).', reservation['id'], lease['name'])
             return False
 
+    @staticmethod
+    def _merge_extras(host, extra_capabilities):
+        if extra_capabilities:
+            res = host.copy()
+            res.update(extra_capabilities)
+            return res
+        return host
+
     def _get_extra_capabilities(self, host_id):
         extra_capabilities = {}
         raw_extra_capabilities = (
@@ -328,13 +336,9 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
 
     def get_computehost(self, host_id):
         host = db_api.host_get(host_id)
-        extra_capabilities = self._get_extra_capabilities(host_id)
-        if host is not None and extra_capabilities:
-            res = host.copy()
-            res.update(extra_capabilities)
-            return res
-        else:
-            return host
+        if host is None:
+            return None
+        return self._merge_extras(host, self._get_extra_capabilities(host_id))
 
     def list_computehosts(self, query=None):
         raw_host_list = db_api.host_list()
@@ -348,13 +352,9 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
 
         host_list = []
         for host in raw_host_list:
-            extra_capabilities = extras_by_host.get(host['id'], {})
-            if extra_capabilities:
-                res = host.copy()
-                res.update(extra_capabilities)
-                host_list.append(res)
-            else:
-                host_list.append(host)
+            host_list.append(
+                self._merge_extras(host,
+                                   extras_by_host.get(host['id'], {})))
         return host_list
 
     def create_computehost(self, host_values):

--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -338,9 +338,23 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
 
     def list_computehosts(self, query=None):
         raw_host_list = db_api.host_list()
+        all_extras = db_api.host_extra_capability_get_all_per_hosts(
+            [h['id'] for h in raw_host_list])
+
+        extras_by_host = {}
+        for capability, property_name in all_extras:
+            extras_by_host.setdefault(capability.computehost_id, {})[
+                property_name] = capability.capability_value
+
         host_list = []
         for host in raw_host_list:
-            host_list.append(self.get_computehost(host['id']))
+            extra_capabilities = extras_by_host.get(host['id'], {})
+            if extra_capabilities:
+                res = host.copy()
+                res.update(extra_capabilities)
+                host_list.append(res)
+            else:
+                host_list.append(host)
         return host_list
 
     def create_computehost(self, host_values):

--- a/blazar/tests/db/sqlalchemy/test_sqlalchemy_api.py
+++ b/blazar/tests/db/sqlalchemy/test_sqlalchemy_api.py
@@ -629,6 +629,20 @@ class SQLAlchemyDBApiTestCase(tests.DBTestCase):
         res = db_api.host_extra_capability_get_all_per_host('1')
         self.assertEqual(2, len(res))
 
+    def test_host_extra_capability_get_all_per_hosts(self):
+        db_api.host_extra_capability_create(
+            _get_fake_host_extra_capabilities(id='1', computehost_id='1'))
+        db_api.host_extra_capability_create(
+            _get_fake_host_extra_capabilities(id='2', computehost_id='1'))
+        db_api.host_extra_capability_create(
+            _get_fake_host_extra_capabilities(id='3', computehost_id='2'))
+        res = db_api.host_extra_capability_get_all_per_hosts(['1', '2'])
+        self.assertEqual(3, len(res))
+        res = db_api.host_extra_capability_get_all_per_hosts(['2'])
+        self.assertEqual(1, len(res))
+        res = db_api.host_extra_capability_get_all_per_hosts([])
+        self.assertEqual(0, len(res))
+
     def test_update_host_extra_capability(self):
         db_api.host_extra_capability_create(
             _get_fake_host_extra_capabilities(id='1'))

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -128,6 +128,9 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         self.db_host_extra_capability_get_all_per_host = self.patch(
             self.db_api, 'host_extra_capability_get_all_per_host')
 
+        self.db_host_extra_capability_get_all_per_hosts = self.patch(
+            self.db_api, 'host_extra_capability_get_all_per_hosts')
+
         self.db_host_extra_capability_get_all_per_name = self.patch(
             self.db_api, 'host_extra_capability_get_all_per_name')
 


### PR DESCRIPTION
for N computehosts with M extra capabilities each, list_computehosts was making the following independent DB queries:

1. list all computehosts
2. For each N computehosts
    - Get computehost
    - get extra capabilities for computehost

Giving 2N+1 db round-trips. For CHI@TACC, this caused up to 10s api response times with ~350 hosts.