### PR TITLE
fix: brittleness in get_servers_per_host

### DIFF
--- a/blazar/tests/utils/openstack/test_nova.py
+++ b/blazar/tests/utils/openstack/test_nova.py
@@ -21,6 +21,7 @@ from novaclient import client as nova_client
 from novaclient import exceptions as nova_exceptions
 from novaclient.v2 import availability_zones
 from novaclient.v2 import hypervisors
+from novaclient.v2 import servers
 from oslo_config import cfg
 from oslo_config import fixture
 
@@ -426,6 +427,8 @@ class FakeNovaHypervisors(object):
     def search(cls, host, servers=False):
         if host == 'multiple':
             return [cls.FakeHost, cls.FakeHost]
+        if host == cls.FakeHost.hypervisor_hostname:
+            return [cls.FakeHost]
         if host == cls.FakeHost.service['host']:
             return [cls.FakeHost]
         else:
@@ -443,6 +446,17 @@ class FakeNovaHypervisors(object):
                 'hypervisor_version': cls.FakeHost.hypervisor_version,
                 'memory_mb': cls.FakeHost.memory_mb,
                 'local_gb': cls.FakeHost.local_gb}
+
+
+class FakeNovaServers(object):
+
+    @classmethod
+    def list(cls, search_opts):
+        host = FakeNovaHypervisors.FakeHost
+        node = search_opts.get("node")
+        if node == host.hypervisor_hostname:
+            return host.servers
+        return []
 
 
 class FakeAvailabilityZones(object):
@@ -487,6 +501,9 @@ class NovaInventoryTestCase(tests.TestCase):
             availability_zones.AvailabilityZoneManager, 'list')
         self.availability_zones.side_effect = FakeAvailabilityZones.list
 
+        self.servers_list = self.patch(servers.ServerManager, 'list')
+        self.servers_list.side_effect = FakeNovaServers.list
+
     def test_get_host_details_with_host_id(self):
         host = self.inventory.get_host_details('1')
         expected = FakeNovaHypervisors.expected()
@@ -529,24 +546,48 @@ class NovaInventoryTestCase(tests.TestCase):
         self.assertEqual(expected, host)
 
     def test_get_servers_per_host(self):
-        servers = self.inventory.get_servers_per_host('fake_name')
+        servers = self.inventory.get_servers_per_host('fake_name.openstack.org')
         self.assertEqual(FakeNovaHypervisors.FakeHost.servers, servers)
+        # hypervisors_search with servers and filtered on hypervisor_hostname
+        # does not work, assert we use servers_list instead.
+        self.hypervisors_search.assert_called_once_with('fake_name.openstack.org')
+        self.servers_list.assert_called_once_with(
+            search_opts={"node": "fake_name.openstack.org", "all_tenants": 1})
 
     def test_get_servers_per_host_with_host_id(self):
         self.assertRaises(manager_exceptions.HostNotFound,
                           self.inventory.get_servers_per_host, '1')
+        self.hypervisors_search.assert_called_once_with('1')
+        self.servers_list.assert_not_called()
 
     def test_get_servers_per_host_with_host_not_found(self):
         self.assertRaises(manager_exceptions.HostNotFound,
                           self.inventory.get_servers_per_host, 'wrong_name')
+        self.hypervisors_search.assert_called_once_with('wrong_name')
+        self.servers_list.assert_not_called()
 
     def test_get_servers_per_host_having_multiple_results(self):
         self.assertRaises(manager_exceptions.MultipleHostsFound,
                           self.inventory.get_servers_per_host, 'multiple')
+        self.hypervisors_search.assert_called_once_with('multiple')
+        self.servers_list.assert_not_called()
 
     def test_get_servers_per_host_with_host_having_no_servers(self):
-        host_with_zero_servers = FakeNovaHypervisors.FakeHost
-        # NOTE(sbauza): We need to simulate a host having zero servers
-        del host_with_zero_servers.servers
-        servers = self.inventory.get_servers_per_host('fake_name')
+        self.servers_list.side_effect = None
+        self.servers_list.return_value = []
+        servers = self.inventory.get_servers_per_host('fake_name.openstack.org')
         self.assertEqual(None, servers)
+        self.hypervisors_search.assert_called_once_with('fake_name.openstack.org')
+        self.servers_list.assert_called_once_with(
+            search_opts={
+                "node": "fake_name.openstack.org",
+                "all_tenants": 1})
+
+    def test_get_servers_per_host_filters_by_hypervisor_hostname(self):
+        # Given the service host name ('fake_name'), servers are still looked
+        # up by the resolved hypervisor_hostname (node), never the service host.
+        servers = self.inventory.get_servers_per_host('fake_name')
+        self.assertEqual(FakeNovaHypervisors.FakeHost.servers, servers)
+        self.hypervisors_search.assert_called_once_with('fake_name')
+        self.servers_list.assert_called_once_with(
+            search_opts={"node": "fake_name.openstack.org", "all_tenants": 1})

--- a/blazar/tests/utils/openstack/test_nova.py
+++ b/blazar/tests/utils/openstack/test_nova.py
@@ -410,7 +410,7 @@ class FakeNovaHypervisors(object):
         local_gb = 10
 
         servers = ['server1', 'server2']
-        service = {'host': 'fake_name'}
+        service = {'host': 'fake_service'}
 
     @classmethod
     def get(cls, host):
@@ -427,9 +427,8 @@ class FakeNovaHypervisors(object):
     def search(cls, host, servers=False):
         if host == 'multiple':
             return [cls.FakeHost, cls.FakeHost]
-        if host == cls.FakeHost.hypervisor_hostname:
-            return [cls.FakeHost]
-        if host == cls.FakeHost.service['host']:
+        # nova matches using LIKE hypervisor_hostname
+        if host in cls.FakeHost.hypervisor_hostname:
             return [cls.FakeHost]
         else:
             raise nova_exceptions.NotFound(404)
@@ -464,7 +463,7 @@ class FakeAvailabilityZones(object):
     class FakeAZ1(object):
         zoneName = 'fake_az1'
         hosts = {
-            "fake_name": {
+            "fake_service": {
                 "nova-compute": {}
             },
         }
@@ -472,7 +471,7 @@ class FakeAvailabilityZones(object):
     class FakeAZ2(object):
         zoneName = 'fake_az2'
         hosts = {
-            "fake_name": {
+            "fake_service": {
                 "nova-conductor": {},
                 "nova-scheduler": {}
             },

--- a/blazar/utils/openstack/nova.py
+++ b/blazar/utils/openstack/nova.py
@@ -432,22 +432,20 @@ class NovaInventory(NovaClientWrapper):
             raise manager_exceptions.InvalidHost(host=host)
 
     def get_servers_per_host(self, host):
-        """List all servers of a nova-compute host
+        """List all servers running on a given Nova hypervisor
 
-        :param host: Name (not UUID) of nova-compute host
-        :return: Dict of servers or None
+        :param host: hypervisor_hostname (or name pattern) of the host
+        :return: list of server or None
         """
         try:
-            hypervisors_list = self.nova.hypervisors.search(host, servers=True)
+            hypervisors_list = self.nova.hypervisors.search(host)
         except nova_exception.NotFound:
             raise manager_exceptions.HostNotFound(host=host)
         if len(hypervisors_list) > 1:
             raise manager_exceptions.MultipleHostsFound(host=host)
-        else:
-            try:
-                return hypervisors_list[0].servers
-            except AttributeError:
-                # NOTE(sbauza): nova.hypervisors.search(servers=True) returns
-                #  a list of hosts without 'servers' attribute if no servers
-                #  are running on that host
-                return None
+
+        hypervisor = hypervisors_list[0]
+        servers = self.nova.servers.list(
+            search_opts={"node": hypervisor.hypervisor_hostname,
+                         "all_tenants": 1})
+        return servers or None


### PR DESCRIPTION
In NovaInventory.get_servers_per_host(), blazar tries to look up whether any nova servers are scheduled to a specific nova hypervisor. However, nova hypervisors may be identified by hypervisor uuid, or the hostname of the hypervisor itself (hypervisor_hostname).

For virtualized nova deployments, host==hypervisor_hostname, but for Ironic backed hosts, many ironic nodes share a single compute service.

Nova's api for hypervisors.search with servers=true will return servers for ALL hypervisors sharing a given compute service, rather than the specific one queried. We have carried a patch in Nova to fall back to matching by hypervisor_hostname as well.

Since this is the only place in blazar consuming this particular api edge case, we can just do the lookup in two steps. First look up the nova hypervisor by id or hypervisor_hostname, and then look up servers using the Nova's servers.list API, which explicitly supports filtering by hypervisor_hostname via the `node` keyword.

If we don't need to preserve the "raise on 0 or >1 hosts found" behavior, the call to hypervisors.search could be dropped, simplifying the logic further.