### PR TITLE
fix(db) Don't create db schema at manager start

### DIFF
--- a/blazar/cmd/manager.py
+++ b/blazar/cmd/manager.py
@@ -25,7 +25,6 @@ from oslo_service import service
 
 gettext.install('blazar')
 
-from blazar.db import api as db_api
 from blazar.manager import service as manager_service
 from blazar.notification import notifier
 from blazar.utils import service as service_utils
@@ -50,7 +49,6 @@ manager_service_instance = None
 def main():
     cfg.CONF(project='blazar', prog='blazar-manager')
     service_utils.prepare_service(sys.argv)
-    db_api.setup_db()
     notifier.init()
     service.launch(
         cfg.CONF,


### PR DESCRIPTION
blazar-manager called db_api.setup_db() on every start, which runs metadata.create_all(). This silently creates any missing tables, but bypasses alembic_versioning. If a manager with new models starts before `blazar-db-manage upgrade head` is run, the new tables will exist and cause conflicts with the alembic migrations.

Starting the manager against an unmigrated database now fails with missing-table errors instead of silently creating them, but it no longer breaks blazar-db-manage, so bootstap during deployment works correctly.