### PR TITLE
Flavor res/02 get all per host

### DIFF
--- a/blazar/cmd/manager.py
+++ b/blazar/cmd/manager.py
@@ -25,7 +25,6 @@ from oslo_service import service
 
 gettext.install('blazar')
 
-from blazar.db import api as db_api
 from blazar.manager import service as manager_service
 from blazar.notification import notifier
 from blazar.utils import service as service_utils
@@ -50,7 +49,6 @@ manager_service_instance = None
 def main():
     cfg.CONF(project='blazar', prog='blazar-manager')
     service_utils.prepare_service(sys.argv)
-    db_api.setup_db()
     notifier.init()
     service.launch(
         cfg.CONF,

--- a/blazar/db/api.py
+++ b/blazar/db/api.py
@@ -461,6 +461,11 @@ def host_resource_inventory_create(values):
     return IMPL.host_resource_inventory_create(values)
 
 
+def host_resource_inventory_get_all_per_host(host_id):
+    """Return all resource inventories belonging to a specific Compute host."""
+    return IMPL.host_resource_inventory_get_all_per_host(host_id)
+
+
 # ComputeHostTrait
 
 def host_trait_create(values):

--- a/blazar/db/api.py
+++ b/blazar/db/api.py
@@ -454,6 +454,20 @@ def host_get_all_by_queries_including_extracapabilities(queries):
     return IMPL.host_get_all_by_queries_including_extracapabilities(queries)
 
 
+# ComputeHostResourceInventory
+
+def host_resource_inventory_create(values):
+    """Create a host resource inventory from the values."""
+    return IMPL.host_resource_inventory_create(values)
+
+
+# ComputeHostTrait
+
+def host_trait_create(values):
+    """Create a host trait from the values."""
+    return IMPL.host_trait_create(values)
+
+
 # FloatingIP reservation
 
 def fip_reservation_create(fip_reservation_values):

--- a/blazar/db/migration/alembic_migrations/versions/553383923ca0_add_compute_host_inventory_and_traits.py
+++ b/blazar/db/migration/alembic_migrations/versions/553383923ca0_add_compute_host_inventory_and_traits.py
@@ -1,0 +1,63 @@
+# Copyright 2024 OpenStack Foundation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Add compute host inventory and traits
+
+Revision ID: 553383923ca0
+Revises: 02e2f2186d98
+Create Date: 2024-04-29 17:40:05.148493
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '553383923ca0'
+down_revision = '02e2f2186d98'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'computehost_resource_inventory',
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.Column('id', sa.String(length=36), nullable=False),
+        sa.Column('computehost_id', sa.String(length=36), nullable=True),
+        sa.Column('resource_class', sa.String(length=255), nullable=False),
+        sa.Column('total', sa.Integer(), nullable=False),
+        sa.Column('reserved', sa.Integer(), nullable=False),
+        sa.Column('min_unit', sa.Integer(), nullable=False),
+        sa.Column('max_unit', sa.Integer(), nullable=False),
+        sa.Column('step_size', sa.Integer(), nullable=False),
+        sa.Column('allocation_ratio', sa.Float(), nullable=False),
+        sa.ForeignKeyConstraint(['computehost_id'], ['computehosts.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table(
+        'computehost_trait',
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.Column('id', sa.String(length=36), nullable=False),
+        sa.Column('computehost_id', sa.String(length=36), nullable=True),
+        sa.Column('trait', sa.String(length=255), nullable=False),
+        sa.ForeignKeyConstraint(['computehost_id'], ['computehosts.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade():
+    op.drop_table('computehost_trait')
+    op.drop_table('computehost_resource_inventory')

--- a/blazar/db/migration/alembic_migrations/versions/553383923ca0_add_compute_host_inventory_and_traits.py
+++ b/blazar/db/migration/alembic_migrations/versions/553383923ca0_add_compute_host_inventory_and_traits.py
@@ -16,14 +16,14 @@
 """Add compute host inventory and traits
 
 Revision ID: 553383923ca0
-Revises: 02e2f2186d98
+Revises: 4fe5e44880da
 Create Date: 2024-04-29 17:40:05.148493
 
 """
 
 # revision identifiers, used by Alembic.
 revision = '553383923ca0'
-down_revision = '02e2f2186d98'
+down_revision = '4fe5e44880da'
 
 from alembic import op
 import sqlalchemy as sa

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -1049,7 +1049,8 @@ def host_resource_inventory_create(values):
 
 
 def host_resource_inventory_get_all_per_host(host_id):
-    with facade_wrapper.session_for_read() as session:
+    session = get_session()
+    with session.begin():
         query = session.query(models.ComputeHostResourceInventory)
         return query.filter_by(computehost_id=host_id).all()
 

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -1026,6 +1026,46 @@ def host_extra_capability_get_all_per_name(host_id, property_name):
             models.ResourceProperty.property_name == property_name).all()
 
 
+# ComputeHostResourceInventory
+
+def host_resource_inventory_create(values):
+    values = values.copy()
+
+    host_resource_inventory = models.ComputeHostResourceInventory()
+    host_resource_inventory.update(values)
+
+    with facade_wrapper.session_for_write() as session:
+        try:
+            host_resource_inventory.save(session=session)
+        except common_db_exc.DBDuplicateEntry as e:
+            # raise exception about duplicated columns (e.columns)
+            raise db_exc.BlazarDBDuplicateEntry(
+                model=host_resource_inventory.__class__.__name__,
+                columns=e.columns)
+
+    return None
+
+
+# ComputeHostTrait
+
+def host_trait_create(values):
+    values = values.copy()
+
+    host_trait = models.ComputeHostTrait()
+    host_trait.update(values)
+
+    with facade_wrapper.session_for_write() as session:
+        try:
+            host_trait.save(session=session)
+        except common_db_exc.DBDuplicateEntry as e:
+            # raise exception about duplicated columns (e.columns)
+            raise db_exc.BlazarDBDuplicateEntry(
+                model=host_trait.__class__.__name__,
+                columns=e.columns)
+
+    return None
+
+
 # FloatingIP reservation
 
 def fip_reservation_create(fip_reservation_values):

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -1034,7 +1034,9 @@ def host_resource_inventory_create(values):
     host_resource_inventory = models.ComputeHostResourceInventory()
     host_resource_inventory.update(values)
 
-    with facade_wrapper.session_for_write() as session:
+    session = get_session()
+
+    with session.begin():
         try:
             host_resource_inventory.save(session=session)
         except common_db_exc.DBDuplicateEntry as e:
@@ -1054,7 +1056,9 @@ def host_trait_create(values):
     host_trait = models.ComputeHostTrait()
     host_trait.update(values)
 
-    with facade_wrapper.session_for_write() as session:
+    session = get_session()
+
+    with session.begin():
         try:
             host_trait.save(session=session)
         except common_db_exc.DBDuplicateEntry as e:

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -1048,6 +1048,12 @@ def host_resource_inventory_create(values):
     return None
 
 
+def host_resource_inventory_get_all_per_host(host_id):
+    with facade_wrapper.session_for_read() as session:
+        query = session.query(models.ComputeHostResourceInventory)
+        return query.filter_by(computehost_id=host_id).all()
+
+
 # ComputeHostTrait
 
 def host_trait_create(values):

--- a/blazar/db/sqlalchemy/models.py
+++ b/blazar/db/sqlalchemy/models.py
@@ -301,6 +301,12 @@ class ComputeHost(mb.BlazarBase, mb.SoftDeleteMixinWithUuid):
                                                   cascade="all,delete",
                                                   backref='computehost',
                                                   lazy='joined')
+    computehost_resource_inventories = relationship(
+        'ComputeHostResourceInventory', cascade="all,delete",
+        backref='computehost', lazy='joined')
+    computehost_traits = relationship(
+        'ComputeHostTrait', cascade="all,delete",
+        backref='computehost', lazy='joined')
 
     def to_dict(self):
         return super(ComputeHost, self).to_dict()
@@ -376,6 +382,34 @@ class ComputeHostExtraCapability(mb.BlazarBase, mb.SoftDeleteMixinWithUuid):
                     f"{self.computehost_id}"
                 )
         return value
+
+
+class ComputeHostResourceInventory(mb.BlazarBase):
+    __tablename__ = 'computehost_resource_inventory'
+
+    id = _id_column()
+    computehost_id = sa.Column(sa.String(36), sa.ForeignKey('computehosts.id'))
+    resource_class = sa.Column(sa.String(255), nullable=False)
+    total = sa.Column(sa.Integer, nullable=False)
+    reserved = sa.Column(sa.Integer, nullable=False)
+    min_unit = sa.Column(sa.Integer, nullable=False)
+    max_unit = sa.Column(sa.Integer, nullable=False)
+    step_size = sa.Column(sa.Integer, nullable=False)
+    allocation_ratio = sa.Column(sa.Float, nullable=False)
+
+    def to_dict(self):
+        return super(ComputeHostResourceInventory, self).to_dict()
+
+
+class ComputeHostTrait(mb.BlazarBase):
+    __tablename__ = 'computehost_trait'
+
+    id = _id_column()
+    computehost_id = sa.Column(sa.String(36), sa.ForeignKey('computehosts.id'))
+    trait = sa.Column(sa.String(255), nullable=False)
+
+    def to_dict(self):
+        return super(ComputeHostTrait, self).to_dict()
 
 
 # Floating IP

--- a/blazar/tests/db/sqlalchemy/test_sqlalchemy_api.py
+++ b/blazar/tests/db/sqlalchemy/test_sqlalchemy_api.py
@@ -743,6 +743,31 @@ class SQLAlchemyDBApiTestCase(tests.DBTestCase):
         expected["updated_at"] = None
         self.assertDictEqual(expected, actual)
 
+    def test_host_resource_inventory_get_all_per_host(self):
+        db_api.host_create(_get_fake_host_values(id=1))
+        fake_inventory_values = {
+            'id': _get_fake_random_uuid(),
+            'computehost_id': '1',
+            'resource_class': 'VCPU',
+            'total': 10,
+            'reserved': 2,
+            'min_unit': 1,
+            'max_unit': 1,
+            'step_size': 1,
+            'allocation_ratio': 1.0
+        }
+        db_api.host_resource_inventory_create(fake_inventory_values)
+
+        result = db_api.host_resource_inventory_get_all_per_host("1")
+
+        result = list(result)
+        self.assertEqual(1, len(result))
+        first_result = result[0].to_dict()
+        expected = fake_inventory_values.copy()
+        expected["updated_at"] = None
+        expected["created_at"] = first_result["created_at"]
+        self.assertDictEqual(expected, first_result)
+
     # Trait
 
     def test_host_traits_create(self):

--- a/blazar/tests/db/sqlalchemy/test_sqlalchemy_api.py
+++ b/blazar/tests/db/sqlalchemy/test_sqlalchemy_api.py
@@ -717,6 +717,52 @@ class SQLAlchemyDBApiTestCase(tests.DBTestCase):
                          db_api.host_extra_capability_get_all_per_name('1',
                                                                        'bad'))
 
+    # Resource Inventory
+
+    def test_host_resource_inventory_create(self):
+        db_api.host_create(_get_fake_host_values(id=1))
+        fake_inventory_values = {
+            'id': _get_fake_random_uuid(),
+            'computehost_id': '1',
+            'resource_class': 'VCPU',
+            'total': 10,
+            'reserved': 2,
+            'min_unit': 1,
+            'max_unit': 1,
+            'step_size': 1,
+            'allocation_ratio': 1.0
+        }
+
+        db_api.host_resource_inventory_create(fake_inventory_values)
+
+        host = db_api.host_get(1)
+        actual = host.computehost_resource_inventories[0].to_dict()
+        self.assertIsNotNone(actual["created_at"])
+        del actual["created_at"]
+        expected = fake_inventory_values.copy()
+        expected["updated_at"] = None
+        self.assertDictEqual(expected, actual)
+
+    # Trait
+
+    def test_host_traits_create(self):
+        db_api.host_create(_get_fake_host_values(id=1))
+        fake_trait_values = {
+            'id': _get_fake_random_uuid(),
+            'computehost_id': '1',
+            'trait': 'HW_CPU_X86_AVX'
+        }
+
+        db_api.host_trait_create(fake_trait_values)
+
+        host = db_api.host_get(1)
+        actual = host.computehost_traits[0].to_dict()
+        self.assertIsNotNone(actual["created_at"])
+        del actual["created_at"]
+        expected = fake_trait_values.copy()
+        expected["updated_at"] = None
+        self.assertDictEqual(expected, actual)
+
     # Instance reservation
 
     def check_instance_reservation_values(self, expected, reservation_id):


### PR DESCRIPTION
Stacked on https://github.com/ChameleonCloud/blazar/pull/170

Backport and fixes for  host_resource_inventory_get_all_per_host 
Change-Id: Ifde07da9513089bde2e9353452e97c0648a756c6
Can be squashed on merge once prior one lands.