### PR TITLE
chi-cleanup: Fix cleanup of preemptable leases

### DIFF
--- a/blazar/tests/utils/openstack/test_nova.py
+++ b/blazar/tests/utils/openstack/test_nova.py
@@ -235,13 +235,15 @@ class ReservationPoolTestCase(tests.TestCase):
 
     def test_add_computehost(self):
         self._patch_get_aggregate_from_name_or_id()
-        self.patch(self.nova, "servers")
+        terminate_preemptibles = self.patch(
+            self.pool, 'terminate_preemptibles')
         self.pool.add_computehost('pool', 'host3')
 
         check0 = self.nova.aggregates.add_host
         check0.assert_any_call(self.fake_aggregate.id, 'host3')
         check1 = self.nova.aggregates.remove_host
         check1.assert_any_call(self.fake_freepool.id, 'host3')
+        terminate_preemptibles.assert_called_with('host3')
 
     def test_add_computehost_with_host_id(self):
         # NOTE(sbauza): Freepool.hosts only contains names of hosts, not UUIDs
@@ -293,6 +295,8 @@ class ReservationPoolTestCase(tests.TestCase):
     def test_add_computehost_revert(self):
         self._patch_get_aggregate_from_name_or_id()
         self.fake_freepool.hosts = ['host1', 'host2']
+        terminate_preemptibles = self.patch(
+            self.pool, 'terminate_preemptibles')
         self.assertRaises(manager_exceptions.HostNotInFreePool,
                           self.pool.add_computehost,
                           'pool', ['host1', 'host2', 'host3'])
@@ -307,6 +311,8 @@ class ReservationPoolTestCase(tests.TestCase):
                                  mock.call(self.fake_freepool.id, 'host2'),
                                  mock.call(self.fake_aggregate.id, 'host1'),
                                  mock.call(self.fake_aggregate.id, 'host2')])
+        terminate_preemptibles.assert_has_calls([mock.call('host1'),
+                                                 mock.call('host2')])
 
     def test_remove_computehost_from_freepool(self):
         self._patch_get_aggregate_from_name_or_id()

--- a/blazar/utils/openstack/nova.py
+++ b/blazar/utils/openstack/nova.py
@@ -262,6 +262,15 @@ class ReservationPool(NovaClientWrapper):
                     except nova_exception.NotFound:
                         raise manager_exceptions.HostNotFound(host=host)
 
+                    # When moving a host out of the freepool, we need to
+                    # terminate preemptible instances before adding hosts to
+                    # the reservation aggregate, which makes them available for
+                    # scheduling.
+                    #
+                    # NOTE(priteau): Preemptibles should not be used with
+                    # instance reservation yet.
+                    self.terminate_preemptibles(host)
+
                 LOG.info("adding host '%(host)s' to aggregate %(id)s",
                          {'host': host, 'id': agg.id})
                 try:
@@ -361,6 +370,20 @@ class ReservationPool(NovaClientWrapper):
 
         metadata = {project_id: None}
         return self.nova.aggregates.set_metadata(agg.id, metadata)
+
+    def terminate_preemptibles(self, host):
+        """Terminate preemptible instances running on host"""
+        for server in self.nova.servers.list(
+                search_opts={"host": host, "all_tenants": 1}):
+            try:
+                LOG.info('Terminating preemptible instance %s (%s)',
+                         server.name, server.id)
+                self.nova.servers.delete(server=server)
+            except nova_exception.NotFound:
+                LOG.info('Could not find server %s, may have been deleted '
+                         'concurrently.', server)
+            except Exception as e:
+                LOG.exception('Failed to delete %s: %s.', server, str(e))
 
 
 class NovaInventory(NovaClientWrapper):

--- a/blazar/utils/openstack/nova.py
+++ b/blazar/utils/openstack/nova.py
@@ -272,20 +272,6 @@ class ReservationPool(NovaClientWrapper):
                 except nova_exception.Conflict as e:
                     raise manager_exceptions.AggregateAlreadyHasHost(
                         pool=pool, host=host, nova_exception=str(e))
-
-                # remove preemptible instances
-                for server in self.nova.servers.list(
-                        search_opts={"node": host, "all_tenants": 1}):
-                    try:
-                        LOG.info('Terminating preemptible instance %s (%s)',
-                                 server.name, server.id)
-                        self.nova.servers.delete(server=server)
-                    except nova_exception.NotFound:
-                        LOG.info('Could not find server %s, may have been '
-                                 'deleted concurrently.', server)
-                    except Exception as e:
-                        LOG.exception(
-                            'Failed to delete %s: %s.', server, str(e))
             except Exception as e:
                 LOG.exception('Error processing host %s: %s', host, str(e))
                 raise e


### PR DESCRIPTION
This change had assumed that only one instance is on a given host, which is true for baremetal, but not for
instance or flavor reservations.

This reverts commit 84fccdf89fe2d0c190f2f1e4fd622ba2cbd7a170.

Change-Id: Icb6dee82b955694e1e58e83e02cc0ebc2776acd0 (cherry picked from commit a587e503be7b58f21ca851ea1b00458b83b0e1a6)