### PR TITLE
Update host monitor to use hypervisor instead of ID

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -1056,25 +1056,24 @@ class PhysicalHostMonitorPlugin(monitor.GeneralMonitorPlugin,
                                       if h['reservable'] is False]
 
                 hvs = self.nova.hypervisors.list()
-                hvs_by_id = {str(hv.id): hv for hv in hvs}
+                hvs_by_hostname = {hv.hypervisor_hostname: hv for hv in hvs}
 
-                failed_hv_ids = [str(hv.id) for hv in hvs
+                failed_hv_hostnames = [hv.hypervisor_hostname for hv in hvs
                                  if hv.state == 'down'
                                  or hv.status == 'disabled']
                 for host in reservable_hosts:
-                    host_id = str(host['id'])
-                    print(host_id)
-                    if host_id in failed_hv_ids:
-                        hv = hvs_by_id.get(host_id)
+                    if host['hypervisor_hostname'] in failed_hv_hostnames:
+                        hv = hvs_by_hostname.get(host['hypervisor_hostname'])
                         error = f"Hypervisor status is {hv.state} and {hv.status}"
                         db_api.host_update(host["id"], {"last_error": error})
                         failed_hosts.append(host)
 
-                active_hv_ids = [str(hv.id) for hv in hvs
+
+                active_hv_hostnames = [hv.hypervisor_hostname for hv in hvs
                                  if hv.state == 'up'
                                  and hv.status == 'enabled']
                 recovered_hosts.extend([host for host in unreservable_hosts
-                                        if host['id'] in active_hv_ids])
+                                        if host['hypervisor_hostname'] in active_hv_hostnames])
 
             aggregates = self.nova.aggregates.list()
             # create a map to get the current aggregate of a host in nova

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -3132,8 +3132,8 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
         hypervisors_list = self.patch(
             self.host_monitor_plugin.nova.hypervisors, 'list')
         hypervisors_list.return_value = [
-            mock.MagicMock(id=1, state='down', status='enabled'),
-            mock.MagicMock(id=2, state='down', status='enabled')]
+            mock.MagicMock(id=1, state='down', status='enabled', hypervisor_hostname="hypvsr1"),
+            mock.MagicMock(id=2, state='down', status='enabled', hypervisor_hostname="hypvsr2")]
 
         result = self.host_monitor_plugin.poll_resource_failures()
         self.assertEqual((hosts, []), result)
@@ -3160,8 +3160,8 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
         hypervisors_list = self.patch(
             self.host_monitor_plugin.nova.hypervisors, 'list')
         hypervisors_list.return_value = [
-            mock.MagicMock(id=1, state='up', status='disabled'),
-            mock.MagicMock(id=2, state='up', status='disabled')]
+            mock.MagicMock(id=1, state='up', status='disabled', hypervisor_hostname="hypvsr1"),
+            mock.MagicMock(id=2, state='up', status='disabled', hypervisor_hostname="hypvsr2")]
 
         result = self.host_monitor_plugin.poll_resource_failures()
         self.assertEqual((hosts, []), result)
@@ -3186,8 +3186,8 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
         hypervisors_list = self.patch(
             self.host_monitor_plugin.nova.hypervisors, 'list')
         hypervisors_list.return_value = [
-            mock.MagicMock(id=1, state='up', status='enabled'),
-            mock.MagicMock(id=2, state='up', status='enabled')]
+            mock.MagicMock(id=1, state='up', status='enabled', hypervisor_hostname="hypvsr1"),
+            mock.MagicMock(id=2, state='up', status='enabled', hypervisor_hostname="hypvsr2")]
 
         result = self.host_monitor_plugin.poll_resource_failures()
         self.assertEqual(([], []), result)
@@ -3208,8 +3208,8 @@ class PhysicalHostMonitorPluginTestCase(tests.TestCase):
         hypervisors_list = self.patch(
             self.host_monitor_plugin.nova.hypervisors, 'list')
         hypervisors_list.return_value = [
-            mock.MagicMock(id=1, state='up', status='enabled'),
-            mock.MagicMock(id=2, state='up', status='enabled')]
+            mock.MagicMock(id=1, state='up', status='enabled', hypervisor_hostname="hypvsr1"),
+            mock.MagicMock(id=2, state='up', status='enabled', hypervisor_hostname="hypvsr2")]
 
         result = self.host_monitor_plugin.poll_resource_failures()
         self.assertEqual(([], hosts), result)


### PR DESCRIPTION
In the past, blazar used to use the same host ID as the nova ID. We stopped doing this, but never updated the nova host monitor code, since we only use ironic hosts. The ironic host handler already uses this.

Change-Id: Ic435bc0538070bebe6d357fac443bffaab56bb3b (cherry picked from commit a862af809ba2ff67348bfc4f597278b130a10032)