### PR TITLE
fix(instance events): get project-id from lease

### DIFF
--- a/blazar/plugins/instances/instance_plugin.py
+++ b/blazar/plugins/instances/instance_plugin.py
@@ -569,18 +569,17 @@ class VirtualInstancePlugin(base.BasePlugin, nova.NovaClientWrapper):
         self.update_resources(reservation_id)
 
     def on_start(self, resource_id, lease=None):
-        ctx = context.current()
         instance_reservation = db_api.instance_reservation_get(resource_id)
         reservation_id = instance_reservation['reservation_id']
 
         try:
             self.nova.flavor_access.add_tenant_access(reservation_id,
-                                                      ctx.project_id)
+                                                      lease['project_id'])
         except nova_exceptions.ClientException:
             LOG.info('Failed to associate flavor %(reservation_id)s '
                      'to project %(project_id)s',
                      {'reservation_id': reservation_id,
-                      'project_id': ctx.project_id})
+                      'project_id': lease['project_id']})
             raise mgr_exceptions.EventError()
 
         pool = nova.ReservationPool()
@@ -603,11 +602,10 @@ class VirtualInstancePlugin(base.BasePlugin, nova.NovaClientWrapper):
     def on_end(self, resource_id, lease=None):
         instance_reservation = db_api.instance_reservation_get(resource_id)
         reservation_id = instance_reservation['reservation_id']
-        ctx = context.current()
 
         try:
             self.nova.flavor_access.remove_tenant_access(
-                reservation_id, ctx.project_id)
+                reservation_id, lease['project_id'])
         except nova_exceptions.NotFound:
             pass
 

--- a/blazar/tests/plugins/instances/test_instance_plugin.py
+++ b/blazar/tests/plugins/instances/test_instance_plugin.py
@@ -1100,7 +1100,7 @@ class TestVirtualInstancePlugin(tests.TestCase):
         mock_host_get = self.patch(db_api, 'host_get')
         mock_host_get.side_effect = fake_host_get
 
-        plugin.on_start('resource-id1')
+        plugin.on_start('resource-id1', lease={"project_id": "fake-project"})
 
         mock_nova.flavor_access.add_tenant_access.assert_called_once_with(
             'reservation-id1', 'fake-project')
@@ -1159,7 +1159,7 @@ class TestVirtualInstancePlugin(tests.TestCase):
             404, "The server doesn't exist in Nova"), Exception('Unknown'),
             None, None, None]
 
-        plugin.on_end('resource-id1')
+        plugin.on_end('resource-id1', lease={"project_id": "fake-project-id"})
 
         mock_nova.flavor_access.remove_tenant_access.assert_called_once_with(
             'reservation-id1', 'fake-project-id')


### PR DESCRIPTION
on_start and on_end read the project from context.current(), but they run in the manager's event processor, where the current context is the service's, not the lease owner's. This works upstream because they use trusts to impersonate the user, but the Chameleon fork removed that mechanism in commit 5b89659b, and 100be4a0 restored it only for end_lease, but not on_start.

This change just reads the project from the lease, which the manager is already passing to the event.
This is already fixed in the host_plugin, so it will only impact instance or (upcoming) flavor reservations.

Extracted from chameleoncloud/2023.1-kvm commit 5204b41a (Mark Powers).
The lease argument itself has been passed by the manager since
2288c10c ("Pass lease to on_* plugin functions").

Co-Authored-By: Mark Powers <markpowers@uchicago.edu>
