### PR TITLE
feat: Restrict flavor reservation hosts by project

### DIFF
--- a/blazar/plugins/flavor/flavor_plugin.py
+++ b/blazar/plugins/flavor/flavor_plugin.py
@@ -96,7 +96,8 @@ class FlavorPlugin(base.BasePlugin):
         start_date = reservation['start_date']
         end_date = reservation['end_date']
         candidates = self._query_available_hosts(
-            start_date, end_date, resource_request, resource_traits)
+            start_date, end_date, resource_request, resource_traits,
+            reservation['project_id'])
 
         # Fail if we have fewer candidates than amount requested
         req_amount = reservation['amount']
@@ -128,7 +129,7 @@ class FlavorPlugin(base.BasePlugin):
             raise mgr_exceptions.MalformedParameter(str(e))
 
     def _query_available_hosts(self, start_date, end_date,
-                               resource_request, resource_traits):
+                               resource_request, resource_traits, project_id):
         # TODO(johngarbutt): offload more of this to the db
         # we should be able to exclude hosts that don't match the
         # resource requests, e.g. baremetal vs virtual
@@ -143,6 +144,14 @@ class FlavorPlugin(base.BasePlugin):
             # ironic (baremetal) hosts; exclude them so they stay available to
             # the physical:host plugin.
             hosts = [h for h in hosts if h['hypervisor_type'] != 'ironic']
+
+        # Honor per-host project restrictions. authorized_projects is an extra
+        # capability, which get_computehost joins to the host for us.
+        hosts = [
+            h for h in hosts
+            if self.is_project_allowed(
+                project_id, self._host_plugin.get_computehost(h['id']))
+        ]
 
         # find reservations for each host in our time period
         free_hosts, reserved_hosts = \

--- a/blazar/tests/plugins/flavor/test_flavor_plugin.py
+++ b/blazar/tests/plugins/flavor/test_flavor_plugin.py
@@ -79,6 +79,7 @@ class TestFlavorPlugin(tests.DBTestCase):
         reservation = {
             'flavor_id': "34eb7166-0e9b-432c-96fd-dff37f22e36e",
             'amount': 4,
+            'project_id': 'fake',
             'affinity': None,
             'start_date': datetime.datetime(2030, 1, 1, 8, 00),
             'end_date': datetime.datetime(2030, 1, 1, 12, 00)
@@ -110,6 +111,7 @@ class TestFlavorPlugin(tests.DBTestCase):
         reservation = {
             'flavor_id': "34eb7166-0e9b-432c-96fd-dff37f22e36e",
             'amount': 5,
+            'project_id': 'fake',
             'affinity': None,
             'start_date': datetime.datetime(2030, 1, 1, 8, 00),
             'end_date': datetime.datetime(2030, 1, 1, 12, 00)
@@ -141,6 +143,7 @@ class TestFlavorPlugin(tests.DBTestCase):
         new_reservation = {
             'flavor_id': "34eb7166-0e9b-432c-96fd-dff37f22e36e",
             'amount': 3,
+            'project_id': 'fake',
             'affinity': None,
             'start_date': datetime.datetime(2030, 1, 1, 8, 00),
             'end_date': datetime.datetime(2030, 1, 1, 12, 00)
@@ -376,7 +379,8 @@ class TestFlavorPlugin(tests.DBTestCase):
             'resource_request': {
                 'VCPU': 1,
             },
-            'resource_traits': {}
+            'resource_traits': {},
+            'project_id': 'fake',
         }
         ret = plugin._query_available_hosts(**query_params)
         self.assertEqual(4, len(ret))
@@ -401,7 +405,8 @@ class TestFlavorPlugin(tests.DBTestCase):
                 'VCPU': 1,
                 'MEMORY_MB': 1024
             },
-            'resource_traits': {}
+            'resource_traits': {},
+            'project_id': 'fake',
         }
         ret = plugin._query_available_hosts(**query_params)
         self.assertEqual(2, len(ret))
@@ -435,6 +440,7 @@ class TestFlavorPlugin(tests.DBTestCase):
             'end_date': datetime.datetime(2020, 7, 7, 19, 0),
             'resource_request': {'VCPU': 1},
             'resource_traits': {},
+            'project_id': 'fake',
         }
 
         # Default (filter_ironic_hosts=True): the ironic host is excluded, so
@@ -450,3 +456,42 @@ class TestFlavorPlugin(tests.DBTestCase):
                         group=plugin.resource_type)
         ret = plugin._query_available_hosts(**query_params)
         self.assertEqual(8, len(ret))
+
+    def test__query_available_hosts_honors_project_restriction(self):
+        get_reservations = self.patch(db_utils,
+                                      'get_reservations_by_host_id')
+        get_reservations.return_value = []
+        plugin = flavor_plugin.FlavorPlugin()
+
+        # A host restricted to project "proj-a" via the authorized_projects
+        # extra capability.
+        self._create_fake_host()
+        db_api.host_extra_capability_create(
+            fake._get_fake_host_extra_capabilities(
+                computehost_id=123, name='authorized_projects',
+                value='proj-a'))
+        db_api.host_resource_inventory_create({
+            'computehost_id': 123,
+            'resource_class': 'VCPU',
+            'total': 4,
+            'reserved': 0,
+            'min_unit': 1,
+            'max_unit': 4,
+            'step_size': 1,
+            'allocation_ratio': 1.0,
+        })
+
+        query_params = {
+            'start_date': datetime.datetime(2020, 7, 7, 18, 0),
+            'end_date': datetime.datetime(2020, 7, 7, 19, 0),
+            'resource_request': {'VCPU': 1},
+            'resource_traits': {},
+        }
+
+        # Authorized project sees the host's 4 slots.
+        ret = plugin._query_available_hosts(project_id='proj-a', **query_params)
+        self.assertEqual(4, len(ret))
+
+        # Unauthorized project sees none.
+        ret = plugin._query_available_hosts(project_id='proj-b', **query_params)
+        self.assertEqual(0, len(ret))


### PR DESCRIPTION
Filter flavor reservation host candidates by the authorized_projects extra capability, matching the behavor for host reservations.

Extracted from Chameleon 2fd82f9


Change-Id: Ib54cf2a1aa07b52982b52365c8efd8babeba1314