### PR TITLE
feat: add lease name+id to flavor description

### DIFF
--- a/blazar/plugins/flavor/flavor_plugin.py
+++ b/blazar/plugins/flavor/flavor_plugin.py
@@ -424,16 +424,22 @@ class FlavorPlugin(base.BasePlugin):
             raise mgr_exceptions.ReservationTypeConflict()
 
         reservation_id = instance_reservation['reservation_id']
+        # instance_reservation doesn't include lease_id, look it up
+        res = db_api.reservation_get(reservation_id)
+        lease = db_api.lease_get(res['lease_id'])
         flavor_details = {
             'flavorid': reservation_id,
             'name': instance_plugin.RESERVATION_PREFIX + ":" + reservation_id,
             'vcpus': source_flavor['vcpus'],
             'ram': source_flavor['ram'],
             'disk': source_flavor['disk'],
-            'is_public': False
+            'is_public': False,
+            'description': f'{lease["name"]} (ID: {lease["id"]})',
         }
-        # create flavor using admin access
-        reserved_flavor = self._instance_plugin.nova.nova.flavors.create(
+        # create flavor using admin access. Need nova microversion >= 2.55 to 
+        # support 'description' field for flavors.
+        nova_client = nova.NovaClientWrapper(version='2.55')
+        reserved_flavor = nova_client.nova.flavors.create(
             **flavor_details)
 
         # Set extra specs to the flavor

--- a/blazar/tests/plugins/flavor/test_flavor_plugin.py
+++ b/blazar/tests/plugins/flavor/test_flavor_plugin.py
@@ -395,6 +395,10 @@ class TestFlavorPlugin(tests.DBTestCase):
         }
         mock_flavor = mock.Mock()
         mock_create.return_value = mock_flavor
+        res_get = self.patch(flavor_plugin.db_api, 'reservation_get')
+        res_get.return_value = {'lease_id': 'lease-1'}
+        lease_get = self.patch(flavor_plugin.db_api, 'lease_get')
+        lease_get.return_value = {'name': 'my-lease', 'id': 'lease-1'}
 
         plugin._create_flavor(fake_reservation)
 
@@ -405,7 +409,8 @@ class TestFlavorPlugin(tests.DBTestCase):
         })
         mock_create.assert_called_once_with(
             flavorid='12345', name='reservation:12345', vcpus=2, ram=1024,
-            disk=10, is_public=False)
+            disk=10, is_public=False,
+            description='my-lease (ID: lease-1)')
 
     def test__query_available_hosts(self):
         get_reservations = self.patch(db_utils,


### PR DESCRIPTION
Give each reserved Nova flavor a human-readable description of the form "<lease name> (ID: <lease id>)" so that users can see which lease each flavor is from. Needs nova microversion >= 2.55 to set flavor description.

Extracted from Chameleon 3d881121 and dd694932
Co-authored-by: Mark Powers <markpowers@uchicago.edu>

Change-Id: I94ab29514af601befdbb9e9b57ad753ef10baf53