### PR TITLE
Generalize placement resource-provider listing

### DIFF
--- a/blazar/tests/utils/openstack/test_placement.py
+++ b/blazar/tests/utils/openstack/test_placement.py
@@ -151,6 +151,41 @@ class TestPlacementClient(tests.TestCase):
             self.client.get_resource_provider, rp_name)
 
     @mock.patch('keystoneauth1.session.Session.request')
+    def test_list_resource_providers(self, kss_req):
+        rp = {'uuid': uuidutils.generate_uuid(), 'name': 'blazar',
+              'generation': 0}
+        mock_json_data = {'resource_providers': [rp]}
+        kss_req.return_value = fake_requests.FakeResponse(
+            200, content=jsonutils.dump_as_bytes(mock_json_data))
+
+        result = self.client.list_resource_providers()
+
+        self._assert_keystone_called_once(
+            kss_req, '/resource_providers?', 'GET')
+        self.assertEqual([rp], result)
+
+    @mock.patch('keystoneauth1.session.Session.request')
+    def test_list_resource_providers_with_query(self, kss_req):
+        mock_json_data = {'resource_providers': []}
+        kss_req.return_value = fake_requests.FakeResponse(
+            200, content=jsonutils.dump_as_bytes(mock_json_data))
+
+        result = self.client.list_resource_providers(
+            query='in_tree=some-uuid')
+
+        self._assert_keystone_called_once(
+            kss_req, '/resource_providers?in_tree=some-uuid', 'GET')
+        self.assertEqual([], result)
+
+    @mock.patch('keystoneauth1.session.Session.request')
+    def test_list_resource_providers_fail(self, kss_req):
+        kss_req.return_value = fake_requests.FakeResponse(404)
+
+        self.assertRaises(
+            exceptions.ResourceProviderListFailed,
+            self.client.list_resource_providers)
+
+    @mock.patch('keystoneauth1.session.Session.request')
     def test_get_traits(self, kss_req):
         rp_uuid = uuidutils.generate_uuid()
 

--- a/blazar/utils/openstack/exceptions.py
+++ b/blazar/utils/openstack/exceptions.py
@@ -19,6 +19,10 @@ class ResourceProviderRetrievalFailed(exceptions.BlazarException):
     msg_fmt = _("Failed to get resource provider %(name)s")
 
 
+class ResourceProviderListFailed(exceptions.BlazarException):
+    msg_fmt = _("Failed to list resource providers")
+
+
 class ResourceProviderCreationFailed(exceptions.BlazarException):
     msg_fmt = _("Failed to create resource provider %(name)s")
 

--- a/blazar/utils/openstack/placement.py
+++ b/blazar/utils/openstack/placement.py
@@ -701,15 +701,33 @@ class BlazarPlacementClient(object):
             rp_uuid,
             [self._get_custom_reservation_trait_name(reserv_uuid, project_id)])
 
-    def list_resource_providers(self):
-        """Get all resource providers."""
-        resp = self.get('/resource_providers')
-        resource_providers = []
+    def list_resource_providers(
+            self, query="", microversion=PLACEMENT_MICROVERSION):
+        """Get all resource providers.
+
+        :param query: A string of query parameters, e.g.
+                      "required=CUSTOM_FOO" or "in_tree=<rp_uuid>".
+        :param microversion: The microversion to use for the request.
+        :return: A list of resource provider information
+        :raise: ResourceProviderListFailed on error.
+        """
+        resp = self.get(
+            f'/resource_providers?{query}', microversion=microversion)
         if resp:
             json_resp = resp.json()
             if json_resp['resource_providers']:
-                resource_providers = json_resp['resource_providers']
-        return resource_providers
+                return json_resp['resource_providers']
+            else:
+                return []
+
+        msg = ("Failed to get resource providers. "
+               "Got %(status_code)d: %(err_text)s.")
+        args = {
+            'status_code': resp.status_code,
+            'err_text': resp.text,
+        }
+        LOG.error(msg, args)
+        raise exceptions.ResourceProviderListFailed()
 
     def get_trait_resource_providers(self, trait_name):
         """Get all resource providers that associate with the trait


### PR DESCRIPTION
Add query and microversion parameters to list_resource_providers so callers can filter server-side: e.g. required=<traits> for trait matching, or in_tree=<rp_uuid> for child resource providers.

Now raises ResourceProviderListFailed on error instead of silently returning an empty list.

Extracted from Chameleon 515a2ee9 and 56b9e23e
Co-authored-by: Mark Powers <markpowers@uchicago.edu>

Change-Id: Ic3732e26e58d4137dffee19ee04242d0b69e5bb6