### PR TITLE
Filter flavor reservations by required traits

### DIFF
--- a/blazar/plugins/flavor/flavor_plugin.py
+++ b/blazar/plugins/flavor/flavor_plugin.py
@@ -135,9 +135,6 @@ class FlavorPlugin(base.BasePlugin):
         # we should be able to exclude hosts that don't match the
         # resource requests, e.g. baremetal vs virtual
         # or missing traits
-        if resource_traits:
-            raise mgr_exceptions.NotImplemented(
-                error="Resource traits not supported yet")
         hosts = db_api.reservable_host_get_all_by_queries([])
 
         if CONF[self.resource_type].filter_ironic_hosts:
@@ -154,6 +151,12 @@ class FlavorPlugin(base.BasePlugin):
                 project_id, self._host_plugin.get_computehost(h['id']))
         ]
 
+        # Keep only hosts Placement says satisfy the flavor's required and
+        # forbidden traits.
+        if resource_traits:
+            matching = self._hostnames_matching_traits(resource_traits)
+            hosts = [h for h in hosts if h["hypervisor_hostname"] in matching]
+
         # find reservations for each host in our time period
         free_hosts, reserved_hosts = \
             self._instance_plugin.filter_hosts_by_reservation(
@@ -168,6 +171,29 @@ class FlavorPlugin(base.BasePlugin):
             hosts_list = self._get_hosts_list(host_info, resource_request)
             available_hosts.extend(hosts_list)
         return available_hosts
+
+    def _hostnames_matching_traits(self, resource_traits):
+        """Hypervisor hostnames whose Placement RP satisfies the traits.
+
+        resource_traits maps a trait name to "required" or "forbidden".
+        Returns the set of matching hostnames (empty if none match).
+        """
+        query_traits = []
+        for trait, value in resource_traits.items():
+            if value == "required":
+                query_traits.append(trait)
+            elif value == "forbidden":
+                # placement expresses a forbidden trait as `!<trait>`
+                query_traits.append(f"!{trait}")
+            else:
+                raise mgr_exceptions.MalformedParameter(
+                    param="trait:%s" % trait
+                )
+
+        rps = self._placement_client.list_resource_providers(
+            query="required=%s" % ",".join(query_traits)
+        )
+        return {rp["name"] for rp in rps or []}
 
     def _get_hosts_list(self, host_info, resource_request):
         """For given host, work out how many instances can fit on it."""

--- a/blazar/tests/plugins/flavor/test_flavor_plugin.py
+++ b/blazar/tests/plugins/flavor/test_flavor_plugin.py
@@ -555,6 +555,70 @@ class TestFlavorPlugin(tests.DBTestCase):
         ret = plugin._query_available_hosts(project_id='proj-b', **query_params)
         self.assertEqual(0, len(ret))
 
+    @mock.patch.object(
+        placement.BlazarPlacementClient, "list_resource_providers"
+    )
+    def test__hostnames_matching_traits(self, mock_list):
+        plugin = flavor_plugin.FlavorPlugin()
+        mock_list.return_value = [{"name": "def"}]
+
+        result = plugin._hostnames_matching_traits(
+            {"CUSTOM_1": "forbidden", "CUSTOM_2": "required"}
+        )
+
+        self.assertEqual({"def"}, result)
+        mock_list.assert_called_once_with(query="required=!CUSTOM_1,CUSTOM_2")
+
+    def test__hostnames_matching_traits_rejects_invalid_value(self):
+        plugin = flavor_plugin.FlavorPlugin()
+        self.assertRaises(
+            mgr_exceptions.MalformedParameter,
+            plugin._hostnames_matching_traits,
+            {"CUSTOM_1": "bogus"},
+        )
+
+    @mock.patch.object(
+        flavor_plugin.FlavorPlugin, "_hostnames_matching_traits"
+    )
+    def test__query_available_hosts_filters_by_traits(self, mock_matching):
+        self.patch(db_utils, "get_reservations_by_host_id").return_value = []
+        plugin = flavor_plugin.FlavorPlugin()
+
+        # Two hosts with VCPU inventory and distinct hypervisor hostnames.
+        for host_id, hv_name in ((456, "def"), (789, "ghi")):
+            self._create_fake_host(id=host_id, hypervisor_hostname=hv_name)
+            db_api.host_resource_inventory_create(
+                {
+                    "computehost_id": host_id,
+                    "resource_class": "VCPU",
+                    "total": 3,
+                    "reserved": 0,
+                    "min_unit": 1,
+                    "max_unit": 4,
+                    "step_size": 1,
+                    "allocation_ratio": 1.0,
+                }
+            )
+
+        query_params = {
+            "start_date": datetime.datetime(2020, 7, 7, 18, 0),
+            "end_date": datetime.datetime(2020, 7, 7, 19, 0),
+            "resource_request": {"VCPU": 1},
+            "resource_traits": {"CUSTOM_1": "required"},
+            "project_id": "fake",
+        }
+
+        # Only hosts Placement matched are kept (3 slots on host 456).
+        mock_matching.return_value = {"def"}
+        ret = plugin._query_available_hosts(**query_params)
+        self.assertEqual(3, len(ret))
+        self.assertTrue(all(h["id"] == "456" for h in ret))
+
+        # No host matches the required trait -> no candidates.
+        mock_matching.return_value = set()
+        ret = plugin._query_available_hosts(**query_params)
+        self.assertEqual(0, len(ret))
+
     def _fake_flavor_details(self):
         return (
             {"VCPU": 1},

--- a/releasenotes/notes/flavor-trait-support-da9f68a3bf600fe7.yaml
+++ b/releasenotes/notes/flavor-trait-support-da9f68a3bf600fe7.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for traits with ``flavor:instance`` reservations.


### PR DESCRIPTION
Maps traits from flavors (required or forbidden) to a placement query,
and filters out hosts not matched by placement.

Extracted from Chameleon https://github.com/ChameleonCloud/blazar/commit/515a2ee9e69cd90d57fccc2a887b4f4c2228a564, https://github.com/ChameleonCloud/blazar/commit/56b9e23e61a8a7223c75fdd37101b8423c8c1b65 and https://github.com/ChameleonCloud/blazar/commit/29abc8a33be4334b27ee37feb245dcfede34fdb3.
(Superseded commits https://github.com/ChameleonCloud/blazar/commit/1ba0fd0e7a424c04b16241a23a5b8abc5a9bf4ef, https://github.com/ChameleonCloud/blazar/commit/6e284623523449e82f199b1fd1869a28be78b7e7 and https://github.com/ChameleonCloud/blazar/commit/ecd9d40761ed5280631cfbb96783ca68f654bead.)

Co-authored-by: Mark Powers <markpowers@uchicago.edu>
Change-Id: I7871b796ba95b6a2aca6bf0343c9676605f20e19