### PR TITLE
prevent crash in host monitor with no reservation

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -1115,6 +1115,9 @@ class PhysicalHostMonitorPlugin(monitor.GeneralMonitorPlugin,
             for host in all_hosts:
                 # get the most recent reservation for the host_id and check if we need to move to freepool
                 reservation = db_utils.get_most_recent_reservation_info_by_host_id(host['id'])
+                # Ignore host if no host reservation exists for it
+                if not reservation:
+                    continue
                 # ignore the reservation which is active, as the host must already be in the right pool
                 if reservation and reservation["reservation_status"] == status.reservation.ACTIVE:
                     LOG.debug(f"{host['hypervisor_hostname']} is in an active reservation"


### PR DESCRIPTION
If a blazar host has never had a host reservation on it, the host monitor would crash when attempting to access the most recent reservation. For now, just skip the host in this case.

TODO: Should hosts be moved to the freepool instead? How should we test this case?

Change-Id: I3ace395855f665e10282e7b3eb2b3ab0e1d32af1