### PR TITLE
Fix crash for plugins without config section

### DIFF
--- a/blazar/manager/service.py
+++ b/blazar/manager/service.py
@@ -862,7 +862,7 @@ class ManagerService(service_utils.RPCServer):
             except exceptions.NotEnoughResourcesAvailable:
                 candidate_ids = None
                 # Retry this function if allowed
-                if hasattr(
+                if plugin.resource_type in CONF and hasattr(
                     CONF[plugin.resource_type],
                     "retry_allocation_without_defaults"
                 ) and CONF[plugin.resource_type]\
@@ -877,7 +877,7 @@ class ManagerService(service_utils.RPCServer):
 
                 # If the retry didn't get candidate IDs, raise an exception
                 if candidate_ids is None:
-                    if hasattr(
+                    if plugin.resource_type in CONF and hasattr(
                         CONF[plugin.resource_type],
                         "display_default_resource_properties"
                     ) and CONF[plugin.resource_type]\


### PR DESCRIPTION
As the instance plugin doesn't declare a config section, checking retry_allocation_without_defaults or display_default_resource_properties raises would raise NoSuchOptError.

First introduced in 23dd353d "Update default resource properties" 
Fix extracted from chameleoncloud/2023.1-kvm-rebase 2c351483.

Change-Id: I6caeb0b45d5d86724f60fc69aba99c5afc8cf1fa