### PR TITLE
Add option to disable physical:host reservation

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -76,6 +76,11 @@ plugin_opts = [
     cfg.BoolOpt('randomize_host_selection',
                 default=False,
                 help='Allocate hosts for reservations randomly.'),
+    cfg.BoolOpt('allow_reservation',
+        default=True,
+        help='Allow users to create host reservations. This plugin must be enabled '
+             'for flavor reservations, but it may not be desirable to allow an '
+             'entire host to be reserved.'),
 ]
 
 plugin_opts.extend(monitor.monitor_opts)
@@ -112,6 +117,9 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
 
     def reserve_resource(self, reservation_id, values):
         """Create reservation."""
+        if not CONF[self.resource_type].allow_reservation:
+            raise manager_ex.UnsupportedResourceType(resource_type=self.resource_type)
+
         ctx = context.current()
         host_ids = self.allocation_candidates(values)
 


### PR DESCRIPTION
Since the host plugin must be enabled as a prerequisite of the flavor plugin, users become able to make both host and flavor reservations. This commit allows disabling the creation of new host reservations via a new config flag, `allow_reservation` under the host plugin.

Extracted from chameleoncloud/2023.1-kvm commit 7d80cf73
Co-authored-by: Mark Powers <markpowers@uchicago.edu>
Change-Id: I23c9752750be75a147afac93d5d1af3a3415d704

Change-Id: I99355b71f39ab2a4a5385abf452c070f657d4364