### PR TITLE
Feat/filter vm hosts

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -81,6 +81,9 @@ plugin_opts = [
         help='Allow users to create host reservations. This plugin must be enabled '
              'for flavor reservations, but it may not be desirable to allow an '
              'entire host to be reserved.'),
+    cfg.BoolOpt('filter_vm_hosts',
+            default=False,
+            help='Only permit ironic (baremetal) hosts to be reserved.'),
 ]
 
 plugin_opts.extend(monitor.monitor_opts)
@@ -809,7 +812,10 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
         else:
             hosts = db_api.reservable_host_get_all_by_queries(filter_array)
         for host in hosts:
-            if not self.is_project_allowed(project_id, self.get_computehost(host["id"])):
+            full_host = self.get_computehost(host["id"])
+            if CONF[self.resource_type].filter_vm_hosts and full_host.get('hypervisor_type') != 'ironic':
+                continue
+            if not self.is_project_allowed(project_id, full_host):
                 continue
             if not db_api.host_allocation_get_all_by_values(
                     compute_host_id=host['id']):

--- a/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
+++ b/blazar/tests/plugins/oshosts/test_physical_host_plugin.py
@@ -3074,6 +3074,50 @@ class PhysicalHostPluginTestCase(tests.TestCase):
         )
         self.assertEqual([], result)
 
+    def test_matching_hosts_filter_vm_hosts(self):
+        """When filter_vm_hosts=True, only ironic hosts are eligible for host reservations."""
+        # Two hosts: one baremetal (ironic), one virtual (QEMU)
+        self.patch(
+            self.db_api,
+            'reservable_host_get_all_by_queries'
+        ).return_value = [
+            {'id': 'host-ironic'},
+            {'id': 'host-vm'},
+        ]
+
+        def fake_host_get(host_id, *args, **kwargs):
+            if host_id == 'host-ironic':
+                return {'id': 'host-ironic', 'hypervisor_type': 'ironic'}
+            return {'id': 'host-vm', 'hypervisor_type': 'QEMU'}
+
+        self.db_host_get.side_effect = fake_host_get
+
+        self.patch(self.db_api, 'host_allocation_get_all_by_values')\
+            .return_value = []
+        self.patch(policy, 'enforce').return_value = False
+
+        # With filter_vm_hosts=True, only the ironic host is returned
+        self.cfg.CONF.set_override(
+            'filter_vm_hosts', True, group='physical:host')
+        result = self.fake_phys_plugin._matching_hosts(
+            '[]', '[]', '1-2',
+            datetime.datetime(2013, 12, 19, 20, 00),
+            datetime.datetime(2013, 12, 19, 21, 00),
+            'fake-project'
+        )
+        self.assertEqual(['host-ironic'], result)
+
+        # With filter_vm_hosts=False (default), both hosts are eligible
+        self.cfg.CONF.set_override(
+            'filter_vm_hosts', False, group='physical:host')
+        result = self.fake_phys_plugin._matching_hosts(
+            '[]', '[]', '1-2',
+            datetime.datetime(2013, 12, 19, 20, 00),
+            datetime.datetime(2013, 12, 19, 21, 00),
+            'fake-project'
+        )
+        self.assertEqual(set(['host-ironic', 'host-vm']), set(result))
+
     def test_check_params_with_valid_before_end(self):
         values = {
             'min': 1,


### PR DESCRIPTION
Adds "filter_vm_hosts" config to physical host plugin. Used for hybrid site so that ironic hosts are eligible for host reservation, but kvm hosts can be restricted to flavor reservations.