### PR TITLE
Add randomization to flavor plugin

### DIFF
--- a/blazar/plugins/flavor/flavor_plugin.py
+++ b/blazar/plugins/flavor/flavor_plugin.py
@@ -13,6 +13,7 @@
 import collections
 import datetime
 import json
+import random
 
 from novaclient import exceptions as nova_exceptions
 from oslo_config import cfg
@@ -39,6 +40,9 @@ plugin_opts = [
                 default=True,
                 help='Filter out ironic (baremetal) hosts from flavor '
                      'reservation candidates.'),
+    cfg.BoolOpt('randomize_host_selection',
+            default=False,
+            help='Allocate hosts for reservations randomly.'),
 ]
 
 CONF = cfg.CONF
@@ -107,6 +111,9 @@ class FlavorPlugin(base.BasePlugin):
         if affinity is not None:
             raise mgr_exceptions.NotImplemented(
                 error="Affinity not supported yet")
+
+        if CONF[self.resource_type].randomize_host_selection:
+            random.shuffle(candidates)
 
         # return just enough hosts to satisfy the request
         while len(candidates) > req_amount:


### PR DESCRIPTION
Similar to host plugin, adds `randomize_host_selection` config to the flavor plugin. This setting causes the allocation candidates for flavor reservation to be shuffled, avoiding packing all reservations into the same hosts.

(cherry picked from commit d19bcbe22f6aef74f54b3adf777ca70aba0a4b14) Change-Id: I18c3b525abf4cdfd039ee3d7b11bcc1492448426