### PR TITLE
get instance reservation by id

### DIFF
--- a/blazar/db/api.py
+++ b/blazar/db/api.py
@@ -323,6 +323,10 @@ def instance_reservation_get(instance_reservation_id):
     return IMPL.instance_reservation_get(instance_reservation_id)
 
 
+def instance_reservation_get_by_reservation_id(reservation_id, session=None):
+    return IMPL.instance_reservation_get_by_reservation_id(reservation_id, session=session)
+
+
 def instance_reservation_update(instance_reservation_id,
                                 instance_reservation_values):
     """Update instance reservation."""

--- a/blazar/db/sqlalchemy/api.py
+++ b/blazar/db/sqlalchemy/api.py
@@ -641,6 +641,13 @@ def instance_reservation_get(instance_reservation_id, session=None):
     return query.filter_by(id=instance_reservation_id).first()
 
 
+def instance_reservation_get_by_reservation_id(reservation_id, session=None):
+    if not session:
+        session = get_session()
+    query = model_query(models.InstanceReservations, session)
+    return query.filter_by(reservation_id=reservation_id).first()
+
+
 def instance_reservation_update(instance_reservation_id, values):
     session = get_session()
 


### PR DESCRIPTION
Adds db query to fetch instance_reservation_get_by_reservation_id. This is needed because instance reservations carry information about "how much" of a resource is used, opposed to only the start and end dates.

Prerequisite for resource usage calculations for flavor calendar and enforcement.

Extracted from chameleoncloud/2023.1-kvm-rebase 04e5b71
Co-authored-by: Mark Powers <markpowers@uchicago.edu>

Change-Id: I3ef04e728ac66bb67c3852052e0f35fa06ea3674