### PR TITLE
Ignore flavor reservations when updating hosts

### DIFF
--- a/blazar/plugins/oshosts/host_plugin.py
+++ b/blazar/plugins/oshosts/host_plugin.py
@@ -29,6 +29,7 @@ from blazar.manager import exceptions as manager_ex
 from blazar.plugins import base
 from blazar.plugins import monitor
 from blazar.plugins import oshosts as plugin
+from blazar.plugins import flavor as flavor_plugin
 from blazar import status
 from blazar.utils.openstack import heat
 from blazar.utils.openstack import ironic
@@ -501,6 +502,8 @@ class PhysicalHostPlugin(base.BasePlugin, nova.NovaClientWrapper):
             datetime.date.max)
 
         for r in reservations:
+            if r['resource_type'] == flavor_plugin.RESOURCE_TYPE:
+                continue
             plugin_reservation = db_utils.get_plugin_reservation(
                 r['resource_type'], r['resource_id'])
 


### PR DESCRIPTION
Users don't specify resource/hypervisor properties when making flavor reservations, so there is no need to check them.

Change-Id: I4f122093cd4de4e358cbe8a5cfe7dbfb8ca1354c (cherry picked from commit 549d6ac300e533acd668419f53dd53897fd2c575)