### PR TITLE
fix(flavor): pass project_id to aggregate create

### DIFF
--- a/blazar/plugins/flavor/flavor_plugin.py
+++ b/blazar/plugins/flavor/flavor_plugin.py
@@ -449,7 +449,12 @@ class FlavorPlugin(base.BasePlugin):
             # [scheduler]placement_aggregate_required_for_tenants=True
             'filter_tenant_id': ctx.project_id,
         }
-        agg = pool.create(name=reservation_id, metadata=pool_metadata)
+
+        agg = pool.create(
+            name=reservation_id,
+            metadata=pool_metadata,
+            project_id=ctx.project_id,
+        )
 
         # TODO(johngarbutt) maybe add inventory here, but mark
         # then inventory as reserved to start with?

--- a/blazar/tests/plugins/flavor/test_flavor_plugin.py
+++ b/blazar/tests/plugins/flavor/test_flavor_plugin.py
@@ -368,8 +368,9 @@ class TestFlavorPlugin(tests.DBTestCase):
         mock_pool_create.assert_called_once_with(
             name="12345",
             metadata={'reservation': '12345',
-                      'filter_tenant_id': 'fake-project-id'}
-        ),
+                      'filter_tenant_id': 'fake-project-id'},
+            project_id='fake-project-id'
+        )
 
     @mock.patch.object(flavors.FlavorManager, 'create')
     def test_create_flavor(self, mock_create):


### PR DESCRIPTION
Chameleon commit a22868f8 refactored the blazar nova api client. 
Unlike upstream, it doesn't take the project_id from ctx.current(), so pass it directly.

Change-Id: If8926e4b77d23e7d73e6e5263ebd1b166ea0b337